### PR TITLE
docs: add Verdict control-plane audit and roadmap

### DIFF
--- a/ARCHITECTURE_GAP_ANALYSIS.md
+++ b/ARCHITECTURE_GAP_ANALYSIS.md
@@ -1,0 +1,149 @@
+# Verdict Target Architecture Gap Analysis
+
+- **Date:** 2026-08-02
+- **Target:** Verdict Core as an ecosystem-neutral AI execution control plane and enforcement layer
+- **Baseline:** `CURRENT_STATE_AUDIT.md`
+- **Scope note:** Memory-unification implementation is being handled separately. Memory governance, shared-context, and RuVector/OpenViking write-path work remain documented as dependencies but are deferred from the immediate issue batch to avoid duplicate ownership.
+
+## Target Invariant
+
+```text
+Eligibility -> Ranking -> Execution Authorization -> Runtime Enforcement
+           -> Verification -> Evidence -> Governed Learning
+```
+
+Learning may improve ranking. It must never create eligibility, authorize execution, weaken a policy, or bypass verification.
+
+## Target Layers and Current Gaps
+
+| Target layer | Existing pieces | Gap | Recommended treatment | Complexity |
+| --- | --- | --- | --- | --- |
+| Intent and `TaskSpec` | Core contracts and routing decisions; Node contract dependency | Task understanding is not yet a complete cross-runtime intake contract with normalized risk/capability requirements | Extend versioned Core contracts; add canonical fixtures and error semantics | M |
+| Decision Kernel | Core classification, catalog, eligibility, availability, ranking, escalation, passports | Decision output is distributed across contracts/modules; no single public decision-kernel API with explicit invariant | Compose existing modules behind a deterministic `DecisionKernel` facade; retain fail-closed semantics | L |
+| Universal `ExecutionEnvelope` | Gateway adapter schemas, runtime passport, task/routing/verification contracts | No single envelope covering decision ID, policy version, models, tools, agents, budgets, timeout, risk, verification, evidence, expiry | Add versioned envelope schema and Python/TypeScript parsers; require it at every gateway | L |
+| Agent Runtime adapter | Gateway adapter interfaces and lifecycle specifications | Ruflo/default/custom runtime adapters are not all implemented and conformance-tested | Implement adapter protocol plus Ruflo adapter first; keep custom runtime adapter minimal | L |
+| Intelligence Provider adapter | Intelligence adapter and memory/code-graph integration points | RuVector/OpenViking/local provider capabilities and write authority are not uniform | Define search/retrieve/ingest/pattern/outcome protocol and provider health semantics | L |
+| Execution Provider adapter | OmniRoute catalog qualification and gateway references | OmniRoute, direct API, local inference, and standalone defaults lack one provider contract | Define execute/health/capabilities/usage/discovery protocol; implement OmniRoute and deterministic local default | M/L |
+| Native enforcement kernel | `lifecycle_controller.py` and lifecycle-hook specification | Required native guards and fail-closed behavior are not proven across all runtime/tool boundaries | Build gateway and hook middleware around immutable envelope; add command/edit/tool/memory guards | XL |
+| Workflow/plugin system | Environment discovery, documentation preflight, guidance, examples, specs | Autonomous Dev is not a versioned plugin with portable stage contracts | Add workflow protocol and ship Autonomous Dev as first-party plugin | L |
+| Governed swarm system | Hivemind/orchestrator references and Ruflo integration direction | No public `SwarmSpec`, supervisor protocol, conflict resolution, or evidence model spanning agents | Add swarm contracts and Ruflo adapter; require per-slice envelopes and supervisor verification | XL |
+| Shared Context Plane | Context packs, local-first memory ADRs, code graph, OpenViking/RuVector bridges | Provider-specific memory conventions and namespaces are not unified | Define context-provider protocol, namespaces, retention, authority, and verified writes | L |
+| Verification | Evaluation, verification plans, test/quality tooling, shadow/counterfactual ADRs | No demonstrated universal gate that consumes requirements, architecture, security, performance, and regression evidence | Add verification orchestrator and typed `VerificationResult`; integrate Core and providers | XL |
+| Evidence | Evidence ledger/receipt modules and ADRs | Chain is not yet guaranteed from request through adapter, runtime, verification, and learning | Add append-only `EvidenceChain` and portable receipt projection with privacy controls | L |
+| Model assignment | Adaptive ranker, intelligence service, catalog, capability qualification | Ranking and assignment are not exposed as a policy-bounded slice-assignment engine; catalog metadata and `auto/*` aliases cannot stand in for per-model proof | Add `ModelAssignmentEngine` after eligibility; record rationale and model/provider attribution; actively probe each concrete model for availability, usage/quota, context, tools, structured output, streaming, vision, and failure behavior under consented budgets | L | High | Decision Kernel, capability data |  
+| Guidance and workflow selection | Guidance specifications, lifecycle hooks, environment discovery, external Ruflo guidance patterns | No provider-neutral guidance plugin contract that recommends tools/workflows without becoming execution authority | Add advisory `GuidanceProvider`/workflow selector plugin; require TaskSpec, policy, capability, freshness, and evidence inputs; guidance may recommend but never authorize | L | High | Decision Kernel, plugin runtime, verification |
+| Memory governance | Durable memory write gate, privacy-safe receipts, local-first plane | Governance is distributed and learning/memory adapters need one write API | Add `MemoryGovernance` with schema, redaction, verification, provenance, rollback | L |
+| Developer experience | CLI/API/dashboard, Node middleware, docs, examples | No single install, local-provider, adapter, workflow, or evidence path is documented and smoke-tested | Add `verdict init`, provider manifests, examples, and integration test harness | M |
+| Repository alignment | Ecosystem README and independent CI | Package/repository names, versions, contracts, release checks, and issue ownership are inconsistent | Publish compatibility manifest and cross-repo release workflow | M |
+
+## Adapter Contracts
+
+Verdict should own these interfaces and semantics:
+
+### Agent Runtime
+
+```text
+submit(envelope) -> run_id
+status(run_id) -> RunStatus
+pause(run_id)
+resume(run_id)
+cancel(run_id)
+collect_results(run_id) -> RuntimeResult
+```
+
+The adapter may schedule agents, but it may not alter the envelope's policy, allowed tools, model set, budget, expiry, or verification requirements.
+
+### Intelligence Provider
+
+```text
+search(query, scope) -> SearchResults
+retrieve(reference) -> ContextRecord
+ingest(record, authority) -> IngestReceipt
+store_pattern(pattern, provenance) -> PatternReceipt
+record_outcome(outcome, evidence_ref) -> OutcomeReceipt
+health() -> ProviderHealth
+```
+
+Retrieval and patterns are advisory. Writes require Core governance and evidence.
+
+### Execution Provider
+
+```text
+execute(envelope, request) -> ExecutionResult
+health() -> ProviderHealth
+capabilities() -> CapabilitySet
+usage(run_id) -> UsageRecord
+discover_models() -> ModelCatalog
+```
+
+The provider is not allowed to substitute an unapproved model or tool. Unknown capability or stale health must be represented explicitly.
+
+## Key Architecture Decisions
+
+### 1. Core remains the authority
+
+`verdict-core` owns contracts, policies, eligibility, execution envelopes, enforcement, evidence, verification, and learning governance. Node, Ruflo, RuVector, OpenViking, OmniRoute, and domain libraries are adapters/providers.
+
+### 2. Contracts before implementations
+
+Extend the existing `contracts/` package and JSON schemas rather than introducing independent contract definitions in every repository. Generate or publish Python and TypeScript artifacts from the same versioned source. Add fixture-based parity tests before changing policy behavior.
+
+### 3. Do not create a second policy authority in Node
+
+Node may retain a compatibility classifier only while it is explicitly marked and proven equivalent. The preferred path is Core decision delegation over a stable API or shared decision artifact. A new `@verdict/policy` package should not become an ungoverned second authority; if created, it must be a generated/conformance surface owned by Core.
+
+### 4. Provider failure is a decision state
+
+Provider outages, stale catalogs, failed qualification, and missing capabilities must yield `unknown`, `degraded`, `approval_required`, or `deny` according to policy. They must not silently trigger an unsafe fallback.
+
+### 5. Workflows are plugins
+
+The autonomous development lifecycle is a workflow/plugin. Core supplies task, slice, context, envelope, hook, evidence, and verification primitives. Ruflo is the default swarm/runtime implementation, not a required architectural dependency.
+
+### 6. Domain packages stay domain packages
+
+Risk, strategy/edge, and backtest should expose provider protocols and receipts. They should not import AI orchestration concerns into deterministic hot paths or become part of the core gateway dependency graph.
+
+## Gap by Required Epic
+
+| # | Epic | Gap closure | Primary repositories | Dependency |
+| ---: | --- | --- | --- | --- |
+| 1 | Decision Kernel | Public deterministic facade for intent normalization, policy, eligibility, ranking, and decision receipts | Core, contracts | None beyond current contracts |
+| 2 | Execution Envelope | Universal immutable, versioned execution authorization | Core/contracts, Node | Decision Kernel |
+| 3 | Adapter Architecture | Runtime, intelligence, and execution provider protocols plus conformance suite | Core/contracts | Envelope |
+| 4 | Standalone Default Providers | Local deterministic runtime/intelligence/execution implementations for usable offline install | Core | Adapter protocols |
+| 5 | Ruflo Integration | Ruflo agent runtime and swarm adapter with bounded envelopes | Core, Ruflo, ecosystem | Runtime adapter, SwarmSpec |
+| 6 | RuVector Integration | RuVector retrieval/pattern/outcome adapter with governed writes | Core, RuVector | Intelligence adapter, memory governance |
+| 7 | OmniRoute Integration | OmniRoute catalog/execute/health provider with qualification and attribution | Core, OmniRoute, Node | Execution provider |
+| 8 | Runtime Enforcement Kernel | Native lifecycle hooks, tool/command/edit guards, loop controls, gateway | Core, Node, provider adapters | Envelope, adapter architecture |
+| 9 | Verification System | Requirements, test, architecture, security, regression, and performance verification orchestrator | Core, all provider repos | Evidence and envelope |
+| 10 | Evidence System | End-to-end append-only evidence chain and portable receipts | Core, all adapters | Verification |
+| 11 | Memory Governance | Redaction, authority, retention, verified writes, rollback, learning boundary | Core, memory providers | Evidence |
+| 12 | Autonomous Development Workflow | Plugin with inventory, repository understanding, research, architecture, slices, implementation, verification | Core, ecosystem, Node/Ruflo adapters | Kernel, context, verification |
+| 13 | Governed Swarm System | `SwarmSpec`, supervisor, role/model assignment, shared context, conflict handling | Core, Ruflo, ecosystem | Workflow and envelope |
+| 14 | Shared Context Plane | Provider-neutral context API for ADRs, RAG, graph, research, history, evidence | Core, RuVector/OpenViking/code graph | Memory governance |
+| 15 | Model Assignment Engine | Policy-bounded role/slice assignment considering reasoning, tools, context, risk, availability, cost | Core, OmniRoute, Node | Decision Kernel |
+| 16 | Repository Alignment | Names, versions, package metadata, schemas, CI, compatibility manifest | Ecosystem and all repos | Contract release |
+| 17 | Developer Experience | CLI, install, examples, local defaults, explainability, integration harness | Core, Node, cockpit, ecosystem | Default providers |
+| 18 | Public Launch Readiness | Security, privacy, performance, reliability, docs, release, support, demo gates | All repos | All preceding epics |
+
+## Non-Goals and Replace Boundaries
+
+- Do not rewrite deterministic risk mathematics, feature evaluation, Monte Carlo simulation, or working Core routing primitives.
+- Do not embed Ruflo-specific APIs into Core domain objects.
+- Do not make the cockpit a policy authority.
+- Do not treat model ranking, memory similarity, or learned patterns as eligibility.
+- Do not claim production readiness from package builds alone; require integration evidence and provider failure tests.
+
+## Acceptance-Level Definition of Target Architecture
+
+The target architecture is reached only when a request can be demonstrated end to end:
+
+1. Core accepts intent and produces a validated `TaskSpec`.
+2. Core gathers context and produces a deterministic decision with policy/version evidence.
+3. Core emits an immutable `ExecutionEnvelope` with allowed models, tools, agents, budget, timeout, risk, verification, evidence, and expiry.
+4. An adapter executes only within that envelope.
+5. Native guards reject out-of-envelope tool, command, edit, loop, and memory writes.
+6. Verification produces a typed `VerificationResult` with required checks and receipts.
+7. Core appends an `EvidenceChain` that identifies decision, policy, runtime, model, tools, changes, verification, and outcome.
+8. Learning receives only verified, privacy-safe outcomes and can improve ranking without changing eligibility.

--- a/CURRENT_STATE_AUDIT.md
+++ b/CURRENT_STATE_AUDIT.md
@@ -1,0 +1,225 @@
+# Verdict Ecosystem Current-State Audit
+
+- **Audit date:** 2026-08-02
+- **Scope:** `verdict-core`, `verdict-node`, `verdict-risk`, `verdict-strategy`, `verdict-backtest`, `verdict-cockpit`, and `verdict-ecosystem`
+- **Evidence:** local repository snapshots, source files, tests, manifests, ADRs, CI workflows, README files, Git history, and existing GitHub issue metadata
+- **Authority:** this audit describes the current repositories; learned-agent suggestions are advisory only
+
+## Executive Summary
+
+Verdict is not starting from zero. `verdict-core` already contains a substantial deterministic routing and policy-control plane: versioned contracts, eligibility, capability passports, availability qualification, routing, evidence receipts, gateway adapters, lifecycle specifications, memory-plane integrations, and verification-oriented ADRs. `verdict-node` is a TypeScript gateway surface with canonical contract consumption, request validation, forwarding, and package verification.
+
+The ecosystem is not yet a single execution-control-plane product. The repositories have different maturity levels and partially overlapping product identities. Core is the authority, but Node still contains policy-adjacent routing behavior; the domain repositories are specialized quantitative engines; the cockpit is currently a small UI/demo surface; and the umbrella repository is documentation-only. Ruflo, RuVector, OpenViking, and OmniRoute are referenced as integrations, but the architecture needs explicit adapter contracts, conformance tests, and fail-closed provider behavior to make those relationships contractual rather than operational convention.
+
+The recommended direction is **reuse Core, extend its contracts and enforcement kernel, integrate external systems through adapters, and avoid a rewrite**. Do not move authority into Node or make Ruflo/RuVector/OmniRoute the architecture. Use versioned contracts and cross-language conformance fixtures to prevent policy drift instead of creating a second policy authority.
+
+## Repository Inventory
+
+| Repository | Current role | Evidence | Maturity | Reuse disposition |
+| --- | --- | --- | --- | --- |
+| `verdict-core` | Python control plane and routing authority | `verdict/`, `contracts/`, `schemas/`, `docs/adr/`, `tests/` | Alpha, largest and most mature | **Retain and extend** |
+| `verdict-node` | TypeScript/Express middleware and OpenAI-compatible gateway | `src/middleware/`, `src/adapters/`, `tests/`, `package.json` | Alpha, package-focused | **Integrate and align** |
+| `verdict-risk` | Deterministic risk gates and stateful risk authority | `src/trade_risk_engine/`, `tests/` | Alpha, focused library | **Adapt as a policy/risk provider** |
+| `verdict-strategy` | Published package namespace `verdict-edge`; feature and expected-value evaluation | `src/edge_mining_framework/`, `tests/` | Alpha | **Adapt as a domain workflow/provider** |
+| `verdict-backtest` | Monte Carlo, fee models, tearsheets, walk-forward primitives | `src/backtest_harness/`, `docs/ARCHITECTURE.md`, `tests/` | Alpha, focused library | **Adapt as simulation and verification provider** |
+| `verdict-cockpit` | Next.js routing/trading dashboard prototype | `src/`, `tests/`, `.github/workflows/ci.yml` | Prototype/demo | **Replace mock data with control-plane APIs; retain UI shell** |
+| `verdict-ecosystem` | Product directory and portfolio README | `README.md` | Documentation-only | **Use as portfolio, roadmap, and cross-repo governance home** |
+
+## Existing Architecture
+
+```text
+                    User or system intent
+                              |
+                              v
+                    verdict-core decision plane
+        contracts -> classification -> eligibility -> ranking
+             |              |              |             |
+             v              v              v             v
+       context/memory   passports       availability   evidence
+                              |
+                              v
+                    gateway adapter boundary
+                         /      |       \
+                        /       |        \
+                 verdict-node  OmniRoute  custom provider
+                        |
+                        v
+                OpenAI-compatible execution
+
+   Specialized providers and workflows:
+   verdict-risk | verdict-strategy/edge | verdict-backtest | Ruflo | RuVector
+
+   Observability surface:
+   verdict-cockpit (currently partially mocked)
+```
+
+Core's model catalog currently exposes a strong qualification direction, but the audit must distinguish catalog identity from operational proof. `verdict/omniroute.py` reads the OpenAI-compatible `/v1/models` catalog; catalog membership is declared evidence, not proof that a concrete model is usable for a specific task. ADR-007, ADR-011, and ADR-012 require consented, bounded probes, while ADR-019 requires fresh negotiated runtime evidence for runtime capabilities. The remaining product gap is a complete per-concrete-model qualification record covering availability, usage/quota/headroom, context, tool calling, structured output, streaming, vision where applicable, latency, errors, provider/account attribution, expiry, and evidence authority. `auto/*` aliases must remain aliases and cannot satisfy that proof requirement.
+
+Core's existing ADR set already points toward the requested direction. Relevant decisions include:
+
+- `docs/adr/ADR-001-evidence-ledger.md` — evidence-ledger direction.
+- `docs/adr/ADR-002-orchestrator-routing.md` — orchestrator routing.
+- `docs/adr/ADR-003-platform-neutral-guidance-boundary.md` — neutral guidance boundary.
+- `docs/adr/ADR-004-local-first-memory-plane.md` — local-first memory.
+- `docs/adr/ADR-006-authoritative-documentation-preflight.md` — documentation preflight.
+- `docs/adr/ADR-009-durable-memory-write-gate.md` — governed memory writes.
+- `docs/adr/ADR-010-fail-closed-capability-passports.md` — capability eligibility.
+- `docs/adr/ADR-015-evidence-authority-and-portable-receipts.md` — portable evidence.
+- `docs/adr/ADR-016-deterministic-policy-and-transition-graphs.md` — deterministic policy transitions.
+- `docs/adr/ADR-019-runtime-negotiated-passports.md` — runtime capability negotiation.
+- `docs/adr/ADR-020-gateway-adapter-contracts.md` — gateway adapter contracts.
+- `docs/architecture/LIFECYCLE_HOOKS_SPECIFICATION.md` — platform-neutral lifecycle hook matrix.
+
+## Implemented Capabilities
+
+### `verdict-core`
+
+Core contains the majority of the target platform primitives:
+
+- Versioned Python and TypeScript contracts under `contracts/`, including `TaskSpec`, routing decisions, verification plans, and contract validation.
+- JSON schemas for contracts, evaluation, context packs, runtime health, runtime passports, and gateway adapters under `schemas/`.
+- Policy-adjacent routing components including classification, catalog discovery, eligibility, availability, adaptive ranking, escalation, and dispatch.
+- Capability qualification and fail-closed passport concepts in `capability_passports.py` and the related ADRs.
+- Evidence and receipt components in `evidence.py` and `evidence_receipts.py`.
+- Gateway adapter interfaces and runtime/conformance helpers in `gateway_adapters.py`, `gateway_adapter_runtime.py`, and `gateway_conformance.py`.
+- Lifecycle controller and a detailed lifecycle-hook specification covering task, prompt, tool/command, edit, session, verification, and error boundaries.
+- Environment discovery, documentation preflight, code-graph integration, intelligence adapters, and memory-plane integration points.
+- CLI, API/server, dashboard, benchmarking, examples, and a large test suite.
+
+Core is therefore the natural home for the Decision Kernel, Execution Envelope, native runtime enforcement, verification, evidence, memory governance, and model-assignment authority.
+
+### `verdict-node`
+
+The Node package provides:
+
+- Express/Next.js middleware entry points in `src/middleware/`.
+- Boundary validation in `src/middleware/validator.ts`.
+- Forwarding and SSE/response handling in `src/middleware/forwarder.ts`.
+- Contract conversion in `src/adapters/contract-to-middleware.ts`.
+- TypeScript package exports, declarations, build, tests, package verification, and dry-run packaging.
+- A dependency on `@bodanglin/verdict-contracts`, which is the correct direction for canonical cross-language contracts.
+
+Node is useful as an edge/runtime adapter, but it must not become a second policy authority. Any policy-adjacent classification or fallback logic should be explicitly marked as a compatibility shim, delegated to Core, or proven equivalent through versioned conformance fixtures.
+
+### `verdict-risk`
+
+Risk is a strong reusable deterministic provider for:
+
+- Pure drawdown, concentration, expected-value, and loss-sequence gates.
+- Stateful kill switches, timed circuit breakers, and consecutive-loss gates.
+- Typed risk state and decisions in `state.py`.
+- A `RiskAuthority` orchestration surface in `engine.py`.
+- Optional OpenTelemetry spans and webhook emission.
+- Paper execution adapter and benchmark tooling.
+
+This is not an AI execution gateway. It is a specialized risk/policy evaluator that can implement a Verdict `RiskProvider` or verification plugin without importing network I/O into the hot path.
+
+### `verdict-strategy` / published `verdict-edge`
+
+The repository implements a small, composable domain evaluator:
+
+- Expected-value gate and Kelly-style sizing in `gate.py`.
+- Safe scalar and time-series feature evaluation in `evaluator.py`.
+- No `eval()`-based expression execution and no exchange SDK requirement in the evaluator.
+- Integration tests for backtest and live-pipeline boundaries.
+
+The repository/package naming is inconsistent: the Git repository is `verdict-strategy`, while `pyproject.toml` and README identify `verdict-edge`. This is a release and ecosystem-alignment issue, not a reason to rewrite the evaluator.
+
+### `verdict-backtest`
+
+Backtest provides:
+
+- Numba-accelerated Monte Carlo equity-path simulation.
+- Fee-model protocol and concrete exchange fee models.
+- Tearsheets, risk statistics, and walk-forward splitting.
+- Deterministic configuration intent and a clear no-live-trading boundary documented in `docs/ARCHITECTURE.md`.
+
+It is reusable as a simulation, counterfactual evaluation, and verification provider. It should not be coupled directly into the core request path.
+
+### `verdict-cockpit`
+
+The cockpit has a working Next.js/React structure and tests for dashboard/store/order-book behavior. Its current source is primarily a UI prototype:
+
+- `src/components/VirtualizedOrderBook.tsx` renders virtualized order-book data.
+- `src/lib/tradingStore.ts` owns state and embeds large mock bid/ask arrays.
+- `src/hooks/useOrderBook.ts` and the dashboard tests provide reusable UI/test patterns.
+
+The cockpit does not yet have a versioned control-plane API client, evidence views, policy decision explorer, authentication/authorization boundary, or live contract-backed data model. Retain the UI shell and replace mock data behind typed API adapters.
+
+### `verdict-ecosystem`
+
+The umbrella repository currently provides product-directory documentation and links. It is the right place for cross-repository release alignment, public roadmap, compatibility matrix, and issue-generation references, but it is not an execution component.
+
+## Reusable Components and Relationships
+
+1. **Core contracts are the canonical boundary.** The `contracts/` package and `schemas/` should be treated as the source of truth for Python/TypeScript interoperability.
+2. **Core gateway adapters are the extension seam.** `gateway_adapters.py`, runtime helpers, and conformance tests should be extended for Ruflo, OmniRoute, direct APIs, and custom runtimes.
+3. **Risk and backtest are provider libraries.** Their deterministic APIs fit evaluation, risk, counterfactual, and verification roles.
+4. **Node is the edge transport.** It should consume contracts and invoke Core decisions, not reproduce the full policy engine.
+5. **Cockpit is an observability/control UI.** Its state and components can be retained while data and authorization move to typed control-plane endpoints.
+6. **Existing ADRs are a design asset.** The target architecture can be delivered by closing gaps in the existing decisions rather than discarding them.
+
+## Duplication and Technical Debt
+
+- Policy-adjacent classification and fallback behavior appears in both Core and Node. Without conformance tests, behavior can drift.
+- Contract artifacts exist in multiple generated/source locations (`contracts/src`, generated TypeScript output, Python contracts, and JSON schemas). The generation/versioning process is not yet an explicit release gate.
+- Repository and package names do not consistently match (`verdict-strategy` versus `verdict-edge`; several README links reference old or alternate names).
+- Core contains generated/runtime directories and extensive agent/tooling artifacts alongside product code; this increases discovery noise and packaging risk.
+- Core has multiple architecture/audit locations (`docs/`, `Docs/`, and archived material), which can make authority and freshness ambiguous.
+- Node's local policy instructions reference Core behavior but there is no automated cross-repository ADR or contract synchronization gate.
+- Cockpit stores mock market data inside a global store and has no stable external data contract.
+- Specialized Python packages have separate manifests, versions, and CI policies; cross-repository compatibility is largely convention-based.
+- Existing issues already cover some memory replacement and lifecycle work in Core (`#210`–`#217`), Node packaging/forwarding (`#8`, `#9`), and ecosystem manifest work (`#1`). New issue generation must link to or supersede these rather than duplicate them.
+
+## Coupling and Risk Areas
+
+### Authority coupling
+
+If Node, Ruflo, or an external model router can independently approve an execution, Verdict's authority invariant is broken. Core must produce the decision and envelope; adapters may execute only within that envelope.
+
+### Contract coupling
+
+Core and Node currently rely on related but separately released artifacts. Schema version, unknown-field handling, secret rejection, and error-category compatibility need automated fixtures and compatibility tests.
+
+### Provider coupling
+
+The README architecture names Ruflo, RuVector, and OmniRoute, but an adapter capability/health contract is required before they can be treated as reliable providers. Provider unavailability must produce explicit `unknown`, `degraded`, or `denied` outcomes, not silent fallback.
+
+### Memory coupling
+
+Core has local-first and governed-memory ADRs, while other repositories inherit operational instructions and may use shared bridges. Namespaces, retention, privacy, authority, and write verification must be versioned; memory retrieval can inform ranking but never bypass eligibility.
+
+### UI coupling
+
+Cockpit currently couples market/order-book state to components and mock data. A typed API/event boundary is needed before it can represent decisions, envelopes, evidence, verification, or policy changes safely.
+
+### Release coupling
+
+Seven repositories have independent versions and workflows. A compatibility manifest, release matrix, and cross-repo contract smoke test are required for public launch readiness.
+
+## Blockers to the Target End State
+
+1. No single, explicitly published universal `ExecutionEnvelope` spanning task, decision, policy, capabilities, budget, timeout, tools, agents, verification, evidence, and expiration.
+2. No complete framework-neutral execution gateway enforcing the envelope at every required native boundary (`pre-tool`, `pre-command`, `pre-edit`, runtime, verification, memory write) across all adapters.
+3. Adapter protocols are present in Core but Ruflo, RuVector, OmniRoute, and standalone defaults are not yet all implemented and conformance-tested as first-class providers.
+4. Verification and evidence primitives exist, but the end-to-end chain from decision to runtime receipt to verification result to durable evidence is not yet demonstrated across each integration.
+5. Learning/ranking exists, but governance, provenance, rollback, and proof that learning cannot bypass policy need a single public contract.
+6. The autonomous development workflow is described by specifications and repository instructions but is not yet a versioned plugin with portable `EnvironmentInventory`, `RepositoryUnderstanding`, `ImplementationResearch`, `AtomicWorkSlice`, and `SwarmSpec` contracts.
+7. Shared context support is fragmented across Core, memory bridges, code graph, OpenViking, and RuVector conventions.
+8. Cross-language and cross-repository CI does not yet provide a complete compatibility/release gate.
+9. Existing local untracked artifacts in some repositories must be preserved and classified before any cleanup or migration.
+
+## Existing GitHub Work to Reuse
+
+At audit time, open issues included:
+
+- `verdict-core`: #210–#217 covering hybrid memory, Ruflo/RuVector memory replacement, statusline, compaction/autopilot, retirement/rollback, ADRs, and governed graph learning.
+- `verdict-node`: #1 (router middleware epic), #8 (forwarding/SSE parity), and #9 (package boundary/publication evidence).
+- `verdict-risk`: #1 (risk engine epic).
+- `verdict-ecosystem`: #1 (ecosystem compatibility and release manifest).
+
+New stories should use `relates to`, `depends on`, or `supersedes` references instead of creating parallel duplicate epics.
+
+## Audit Conclusion
+
+Verdict Core already has the architectural seed and several implemented primitives for the requested end state. The highest-leverage work is contract consolidation, runtime enforcement, adapter conformance, evidence/verification closure, and cross-repository release alignment. The specialized risk, strategy, and backtest libraries should remain composable providers. The cockpit and Node package should become governed surfaces over Core, not independent authorities.

--- a/IMPLEMENTATION_LIFT_ANALYSIS.md
+++ b/IMPLEMENTATION_LIFT_ANALYSIS.md
@@ -1,0 +1,112 @@
+# Verdict Implementation Lift Analysis
+
+- **Date:** 2026-08-02
+- **Estimate scale:** XS < 1 engineer-week; S 1–2; M 3–5; L 6–10; XL 11+ engineer-weeks
+- **Order rule:** Reuse → Extend → Integrate → Replace → Build New
+- **Important:** estimates include implementation, tests, contract fixtures, and integration verification, not just code volume
+- **Scope note:** Memory-unification implementation is owned by another active effort. Memory governance, shared-context, and RuVector/OpenViking write-path items are deferred from the immediate issue batch; retain them as dependencies and integration checks only.
+
+## Capability Lift Matrix
+
+| Capability | Current reuse | Affected repositories | Approach | Effort | Risk | Dependencies |
+| --- | --- | --- | --- | ---: | --- | --- |
+| Task understanding and normalization | Core contracts, classifier, context pack | Core, contracts, Node | Extend contracts and deterministic intake facade | M | Medium | Contract versioning |
+| Decision Kernel | Core eligibility, availability, passports, ranker, escalation | Core, contracts, Node | Compose existing modules behind one public API | L | High | TaskSpec, policy transition rules |
+| Universal Execution Envelope | Gateway/runtime schemas and verification plans | Core, contracts, Node, adapters | Build one immutable versioned envelope and parsers | L | High | Decision Kernel |
+| Agent Runtime adapter | Core gateway adapter seam; Ruflo available externally | Core, Ruflo, Node | Integrate Ruflo first; add minimal local runtime | L | High | Envelope, lifecycle events |
+| Intelligence Provider adapter | Core intelligence/memory/code graph hooks | Core, RuVector, OpenViking | Extend into provider-neutral protocol with health and write receipts | L | High | Memory governance, evidence |
+| Execution Provider adapter | OmniRoute qualification/catalog surfaces | Core, OmniRoute, Node | Integrate OmniRoute; add local/direct HTTP provider | M/L | High | Envelope, capability passport |
+| Native runtime enforcement | Lifecycle controller and lifecycle-hook specification | Core, Node, Ruflo adapters | Extend to tool, command, edit, loop, and memory gates | XL | Critical | Envelope, adapter integration |
+| Verification orchestrator | Evaluation, tests, quality tooling, shadow/counterfactual ADRs | Core, all repos | Build typed verification pipeline and provider hooks | XL | Critical | Evidence, runtime receipts |
+| Evidence chain | Evidence ledger, receipts, privacy-safe receipt ADRs | Core, all adapters | Extend append-only chain and portable receipt format | L | High | Envelope, verification |
+| Memory governance | Durable write gate and local-first memory ADRs | Core, RuVector/OpenViking, all repos | Centralize redaction, authority, retention, rollback, learning boundary | L | Critical | Evidence, provider protocol |
+| Model assignment | Adaptive ranker, catalog, intelligence service | Core, OmniRoute, Node, Ruflo | Build policy-bounded slice assignment after eligibility; replace alias-only confidence with consented, budgeted concrete-model qualification and per-model capability/usage receipts | L | Critical | Decision Kernel, capability data, probe scheduler |  
+| Guidance/workflow selection | Guidance specs, lifecycle hooks, environment discovery, external Ruflo guidance patterns | Core, ecosystem, Ruflo/other adapters | Add advisory provider-neutral guidance plugin and workflow selector; recommendations cannot authorize execution or bypass eligibility | L | High | Decision Kernel, plugin runtime, verification |
+| Workflow/plugin runtime | Environment discovery, documentation preflight, guidance specs | Core, ecosystem | Build plugin contract and lifecycle runner | L | High | Envelope, context, verification |
+| Autonomous Dev workflow | Existing specs and development conventions | Core, ecosystem, Ruflo, Node | Implement flagship plugin in atomic stages | XL | Critical | Plugin runtime, swarm system |
+| Governed swarms | Orchestrator/hivemind direction and Ruflo swarm | Core, Ruflo, ecosystem | Define SwarmSpec, supervisor, conflict/evidence rules | XL | Critical | Workflow, envelope, context |
+| Shared Context Plane | Context packs, graph bridge, memory plane, OpenViking/RuVector hooks | Core, RuVector, OpenViking, ecosystem | Provider-neutral context API and namespace/version rules | L | High | Memory governance |
+| Default standalone providers | Core local capabilities and HTTP primitives | Core | Build deterministic local runtime/intelligence/execution defaults | M/L | Medium | Adapter protocols |
+| Node alignment | Existing middleware and canonical contracts dependency | Node, Core/contracts | Delegate/consume Core decisions; add parity and failure tests | L | High | Envelope, adapter API |
+| Cockpit control-plane UI | Existing Next.js shell, tests, Zustand components | Cockpit, Node, Core | Replace mock data with typed API/events and evidence views | L | Medium/High | Public API, auth, envelope |
+| Risk provider integration | `RiskAuthority`, gates, state, telemetry | Risk, Core | Add provider adapter and signed/portable risk receipt | M | High | Provider contracts, evidence |
+| Strategy/edge integration | Feature evaluator and EV gate | Strategy, Core, backtest | Expose evaluation provider and verification result | M | Medium | Domain provider contract |
+| Backtest integration | Monte Carlo, fees, tearsheets, walk-forward | Backtest, Core, strategy, risk | Expose simulation/counterfactual provider | M | Medium | Evidence and verification |
+| Repository/release alignment | Ecosystem README and independent CI | All repos, ecosystem | Compatibility manifest, release train, contract smoke tests | M | High | Versioned contracts |
+| Developer experience | CLI/API/dashboard/examples and package verification | Core, Node, Cockpit, ecosystem | Add init, explain, local defaults, integration harness | M/L | Medium | Default providers |
+| Public launch readiness | Separate CI/security/release workflows | All repos | Cross-repo gates, security/privacy/perf/reliability evidence | L | Critical | All epics |
+
+## Epic-by-Epic Lift
+
+| Epic | Priority | Recommended implementation | Repositories | Effort | Definition of meaningful progress |
+| --- | --- | --- | --- | ---: | --- |
+| 1. Decision Kernel | P0 | Extend Core; do not rewrite routing modules | Core, contracts | L | One deterministic API returns decision, exclusions, rationale, policy version, and receipt |
+| 2. Execution Envelope | P0 | Build from existing schemas and gateway contracts | Core, contracts, Node | L | Every execution request validates one immutable envelope with expiry and limits |
+| 3. Adapter Architecture | P0 | Formalize three provider protocols and conformance harness | Core, contracts | L | A fake provider can be tested without provider-specific imports |
+| 4. Standalone Default Providers | P1 | Build offline deterministic defaults | Core | M/L | Fresh install runs a complete governed demo without Ruflo/RuVector/OmniRoute |
+| 5. Ruflo Integration | P1 | Implement runtime and swarm adapters behind contracts | Core, Ruflo, ecosystem | L | Ruflo run receives envelope and emits status/results/evidence |
+| 6. RuVector Integration | P1 | Implement governed intelligence/memory adapter | Core, RuVector, ecosystem | L | Search can inform ranking; writes require verification and receipt |
+| 7. OmniRoute Integration | P1 | Implement execution/catalog/health adapter | Core, OmniRoute, Node | M/L | Model discovery and execution are qualified, attributed, and fail closed |
+| 8. Runtime Enforcement Kernel | P0 | Extend lifecycle controller into native gateway/guards | Core, Node, adapters | XL | Out-of-envelope tool/command/edit/memory actions are denied and evidenced |
+| 9. Verification System | P0 | Build typed verification orchestrator | Core, all repos | XL | Completion requires requirements, tests, security, regression, and performance evidence as configured |
+| 10. Evidence System | P0 | Close the append-only chain | Core, all repos | L | One portable chain joins decision, runtime, changes, verification, and outcome |
+| 11. Memory Governance | P0 | Centralize governed memory writes and learned outcomes | Core, providers | L | Unverified or secret-bearing writes are rejected; rollback is possible |
+| 12. Autonomous Development Workflow | P1 | Implement plugin stages and slice contracts | Core, ecosystem, Ruflo, Node | XL | A repository task runs discovery→research→architecture→slice→implementation→verification |
+| 13. Governed Swarm System | P1 | Add SwarmSpec and supervisor | Core, Ruflo, ecosystem | XL | Supervisor delegates bounded slices and resolves conflicts with evidence |
+| 14. Shared Context Plane | P1 | Normalize provider-neutral context records and namespaces | Core, providers, ecosystem | L | Agents receive same scoped ADR/RAG/graph/history context with provenance |
+| 15. Model Assignment Engine | P1 | Add policy-bounded role/slice assignment | Core, OmniRoute, Ruflo | L | Assignment records reasoning tier, tool/context/risk needs, availability, and provider |
+| 16. Repository Alignment | P0 | Fix package names, versions, CI, and compatibility manifest | All repos, ecosystem | M | A release matrix catches incompatible contract/package combinations |
+| 17. Developer Experience | P1 | Add CLI setup, explainability, local demo, and integration harness | Core, Node, Cockpit, ecosystem | M/L | New developer can install and inspect a governed execution locally |
+| 18. Public Launch Readiness | P0 | Run cross-repo security, privacy, perf, docs, and release gates | All repos | L | Launch checklist is backed by reproducible evidence, not README claims |
+
+## Highest-Risk Work
+
+1. **Runtime enforcement kernel:** a bypass here invalidates the product claim. It requires adversarial tests and adapter-specific integration tests.
+2. **Verification/evidence closure:** an agent-reported success cannot be accepted without independent evidence and immutable provenance.
+3. **Memory governance:** learning and retrieval can silently become policy bypasses or privacy leaks if write authority is not centralized.
+4. **Cross-language contracts:** Python/TypeScript drift can cause incompatible enforcement decisions at the Node boundary.
+5. **Ruflo/provider adapters:** provider behavior must be bounded and observable; provider availability cannot be treated as authority.
+6. **Public release alignment:** independent repositories and package names currently make compatibility assumptions easy to miss.
+
+## Reuse Decisions
+
+### Reuse directly
+
+- Core policy, eligibility, availability, passport, evidence, contract, context-pack, lifecycle, gateway, and verification primitives.
+- Risk gates and typed state.
+- Strategy feature/EV evaluation.
+- Backtest fee, simulation, and analytics primitives.
+- Node middleware transport and package verification.
+- Cockpit UI components and test harness where not coupled to mock data.
+
+### Extend
+
+- Core contracts into `ExecutionEnvelope`, `VerificationResult`, `EvidenceChain`, `SwarmSpec`, and plugin stage objects.
+- Core lifecycle controller into native enforcement gateway and guards.
+- Existing provider qualification into all adapter health/capability semantics.
+- Existing CI into cross-repo compatibility and evidence gates.
+
+### Integrate
+
+- Ruflo as the first agent runtime/swarm adapter.
+- RuVector/OpenViking/code graph as intelligence/context providers.
+- OmniRoute as the first execution provider.
+- Specialized domain packages as risk/evaluation/simulation providers.
+
+### Replace selectively
+
+- Cockpit mock state/data path with typed control-plane API/event adapters.
+- Node policy-adjacent heuristics with Core decisions or generated conformance behavior.
+- Ambiguous package/repository metadata with canonical names and compatibility aliases where migration requires them.
+
+### Build new
+
+- Universal immutable execution envelope.
+- Native enforcement kernel across all required lifecycle boundaries.
+- Provider-neutral plugin and swarm contracts.
+- End-to-end verification/evidence chain.
+- Public compatibility/release manifest and launch gate.
+
+## Overall Estimate
+
+A credible first public control-plane milestone is approximately **70–110 engineer-weeks** distributed across parallel workstreams, with the enforcement, verification, evidence, and swarm areas on the critical path. This is a planning range, not a delivery commitment. A narrower alpha milestone can be reached sooner by limiting the first supported path to Core + Node + OmniRoute + local defaults, then adding Ruflo/RuVector and domain providers behind the same contracts.

--- a/IMPLEMENTATION_RESEARCH.md
+++ b/IMPLEMENTATION_RESEARCH.md
@@ -1,0 +1,69 @@
+# Verdict Implementation Research and Architecture Decisions
+
+- **Date:** 2026-08-02
+- **Purpose:** Record the reuse-first research conclusions that precede ticket generation.
+
+## Product Boundary
+
+Verdict Core is the authority layer between intent and execution. It owns contracts, policy, eligibility, execution envelopes, enforcement, verification, evidence, and governed learning. External systems provide capabilities through adapters.
+
+This boundary is supported by Core's existing platform-neutral guidance ADR, gateway adapter ADR, evidence ADRs, capability passport ADRs, and lifecycle-hook specification.
+
+## Options Considered
+
+### Make Ruflo the core architecture
+
+**Rejected.** This would couple Verdict's public contracts and enforcement semantics to one runtime. Ruflo remains the default runtime/swarm implementation, but a custom runtime must be able to implement the same adapter contract.
+
+### Make OmniRoute the policy/router authority
+
+**Rejected.** OmniRoute can provide model discovery, execution, health, usage, and provider selection. Eligibility, policy, risk, and verification remain Verdict decisions.
+
+### Make RuVector/OpenViking the memory authority
+
+**Rejected.** They can provide retrieval, graph, indexing, and pattern capabilities. Verdict owns memory-write governance, privacy, provenance, retention, and the rule that learning cannot bypass policy.
+
+### Create a second Node policy package
+
+**Rejected as the first move.** Node currently needs compatibility behavior, but a second policy authority would increase drift. First publish canonical schemas and conformance fixtures; then either delegate decisions to Core or generate a strictly equivalent language binding owned by Core.
+
+### Rewrite the domain repositories into Core
+
+**Rejected.** Risk, strategy, and backtest are focused deterministic libraries. Adapting them as providers preserves useful isolation, performance, and testability.
+
+### Build a new orchestration framework
+
+**Rejected.** Core already has routing, lifecycle, gateway, context, evidence, memory, and verification building blocks. Build only missing control-plane primitives and workflow/plugin contracts.
+
+## Chosen Direction
+
+1. **Core-first authority:** extend `verdict-core` rather than introduce a new central repository.
+2. **Contract-first integration:** version Python/TypeScript/JSON artifacts together.
+3. **Fail-closed qualification:** unknown, stale, missing, or unqualified capabilities cannot authorize execution.
+4. **Immutable execution envelope:** every adapter receives a bounded envelope with policy, identity, capabilities, budget, timeout, allowed actions, verification, evidence, and expiry.
+5. **Native enforcement:** hooks and guards execute at task, tool, command, edit, runtime, verification, and memory-write boundaries.
+6. **Plugin workflows:** Autonomous Dev is the flagship workflow, not hardcoded into the kernel.
+7. **Provider-neutral context:** RAG, ADRs, code graph, history, and evidence are context sources with provenance, not policy authorities.
+8. **Evidence before learning:** only verified, redacted outcomes may update ranking or patterns.
+
+## Additional Direction: Concrete-Model Qualification and Guidance
+
+Catalog membership and `auto/*` aliases are insufficient evidence for model selection. The execution-provider contract must distinguish aliases from concrete model IDs and require active, consented, budgeted qualification for each concrete model intended for protected work. Qualification should record sanitized, expiring evidence for availability, usage/quota/headroom, context limits, tool calling, structured output, streaming, vision or other declared capabilities, latency, error/fallback behavior, and provider/account attribution. A catalog entry may remain visible as `declared`, but it cannot become `eligible` for protected execution without fresh direct evidence. Existing probe ADRs support this direction: `ADR-007`, `ADR-011`, `ADR-012`, `ADR-013`, `ADR-014`, and `ADR-019`.
+
+Guidance should be integrated as a provider-neutral advisory plugin/workflow, not copied as a second authority. A guidance provider can inspect TaskSpec, repository/context evidence, available capabilities, policy constraints, and freshness, then recommend a workflow, tools, roles, or model-assignment strategy. Core must re-evaluate every recommendation through eligibility, envelope creation, runtime enforcement, verification, and evidence. Ruflo Guidance can be the first adapter/reference implementation; the contract must remain usable by other runtimes.
+
+## Research Gaps Requiring First-Class Tickets
+
+- Exact public API and serialization of `ExecutionEnvelope`.
+- Compatibility/version policy between Core contracts and `@bodanglin/verdict-contracts`.
+- Ruflo runtime event/status mapping and cancellation semantics.
+- RuVector/OpenViking provider health, namespace, retention, and write receipts.
+- OmniRoute model discovery/usage attribution and failure states.
+- Native guard behavior for each supported host/runtime.
+- Verification policy profiles for code, infrastructure, financial, and other high-risk tasks.
+- Evidence-chain storage/portability and privacy redaction guarantees.
+- Cross-repository release and migration policy for `verdict-strategy`/`verdict-edge` naming.
+
+## Research Conclusion
+
+The shortest credible path is not a rewrite. It is a bounded Core authority milestone with local defaults, a complete envelope/enforcement/evidence path, and one provider of each type. Ruflo, RuVector, and OmniRoute should then be added through conformance-tested adapters. The domain repositories and cockpit follow after the authority path is independently verifiable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,129 @@
+# Verdict Autonomous AI Control-Plane Roadmap
+
+- **Date:** 2026-08-02
+- **Status:** Proposed execution roadmap derived from the current-state audit and lift analysis
+- **Scope note:** Memory-unification work is intentionally deferred from this execution batch because another effort owns it. Do not create duplicate memory tickets; resume with integration and verification after that work lands.
+
+## Phase 0 — Baseline and Contract Freeze
+
+**Goal:** Establish the source of truth before implementation.
+
+- Accept and publish the current-state, gap, lift, and research documents.
+- Inventory existing GitHub issues and link duplicates/superseded work.
+- Freeze contract versioning and generate Python/TypeScript/JSON compatibility fixtures.
+- Resolve package/repository naming and release metadata inconsistencies.
+- Publish a compatibility manifest from `verdict-ecosystem`.
+
+**Gate:** No new execution feature proceeds without an owning contract, policy, evidence, and verification story.
+
+## Phase 1 — Decision Kernel and Execution Envelope
+
+**Goal:** Make the authority path explicit and testable.
+
+- Compose Core's existing classifier, eligibility, availability, capability passport, ranking, and escalation into a public `DecisionKernel`.
+- Add `ExecutionEnvelope` and parsers in Core/contracts.
+- Add policy version, decision ID, expiry, allowed models/tools/agents, budget, timeout, risk constraints, verification requirements, and evidence references.
+- Add explainability and denial reasons.
+
+**Gate:** A deterministic request produces a validated decision and immutable envelope without any provider execution.
+
+## Phase 2 — Adapter Architecture and Default Providers
+
+**Goal:** Make Verdict usable without a mandatory external runtime.
+
+- Formalize Agent Runtime, Intelligence Provider, and Execution Provider interfaces.
+- Build deterministic local runtime/intelligence/execution defaults.
+- Add provider health, capabilities, usage, discovery, and explicit unknown/degraded states.
+- Implement conformance tests and a fake provider test harness.
+- Add a concrete-model qualification scheduler: enumerate real model IDs, exclude alias-only entries from qualification, run consented/budgeted probes per model, and persist expiring sanitized receipts for capability, usage/quota, headroom, latency, and failure behavior.
+
+**Gate:** Every model eligible for protected work has fresh direct evidence; `auto/*` aliases alone never qualify a route.
+
+**Guidance boundary:** Add an advisory provider-neutral guidance plugin/workflow contract. Ruflo Guidance may be the first adapter, but guidance recommendations must flow back through Core eligibility and envelope enforcement.
+
+
+**Gate:** Offline end-to-end demo runs through the same envelope path as external providers.
+
+## Phase 3 — Native Runtime Enforcement
+
+**Goal:** Ensure the envelope is enforced, not advisory.
+
+- Extend Core lifecycle controller and hook specification into native guards.
+- Enforce pre-tool, pre-command, pre-edit, loop, runtime, verification, and memory-write boundaries.
+- Add command/edit root and credential protections.
+- Add pause/resume/cancel/timeout/approval behavior.
+- Emit receipts for allowed, approval-required, denied, degraded, and failed transitions.
+
+**Gate:** Adversarial tests demonstrate that an adapter cannot exceed the envelope.
+
+## Phase 4 — Verification and Evidence Closure
+
+**Goal:** Replace agent claims with independent evidence.
+
+- Implement typed `VerificationResult` and verification profiles.
+- Run requirements, tests, architecture, regression, security, privacy, and performance checks according to policy.
+- Implement append-only `EvidenceChain` and portable receipt projection.
+- Link decision, policy, runtime, model, tools, changes, verification, and outcome.
+
+**Gate:** Completion is impossible without configured verification evidence; evidence is privacy-safe and portable.
+
+## Phase 5 — First-Class Integrations
+
+**Goal:** Add opinionated defaults without changing the architecture.
+
+- Ruflo runtime and governed swarm adapter.
+- RuVector/OpenViking/context provider adapters.
+- OmniRoute execution/catalog/health adapter.
+- Node middleware delegation and envelope enforcement.
+- Cross-provider failure, qualification, attribution, and cancellation tests.
+
+**Gate:** Each provider passes the same conformance suite and produces evidence-bearing runs.
+
+## Phase 6 — Autonomous Dev and Governed Swarms
+
+**Goal:** Ship the flagship workflow as a plugin.
+
+- `EnvironmentInventory` stage.
+- `RepositoryUnderstanding` stage using source, ADRs, memory, RAG, code graph, and provider capabilities.
+- Memory-first tool selection and documentation preflight.
+- `IMPLEMENTATION_RESEARCH` and architecture decision stage.
+- Atomic work-slice compiler.
+- Model assignment engine.
+- `SwarmSpec`, supervisor, shared context, conflict handling, and per-slice verification.
+
+**Gate:** A repository task completes the full lifecycle with bounded delegation and a complete evidence chain.
+
+## Phase 7 — Product Surfaces and Launch
+
+**Goal:** Make the control plane adoptable and supportable.
+
+- Replace cockpit mock data with typed control-plane APIs/events.
+- Add policy decision explorer, envelope viewer, evidence-chain viewer, verification status, provider health, and audit views.
+- Publish install, local development, provider setup, adapter authoring, and migration guides.
+- Run security/privacy/performance/reliability launch gates.
+- Publish compatible package versions and release notes.
+
+**Gate:** Public launch checklist is satisfied by reproducible CI and demo evidence.
+
+## Critical-Path Ordering
+
+```text
+Contract freeze
+  -> Decision Kernel
+  -> Execution Envelope
+  -> Adapter conformance + defaults
+  -> Native enforcement
+  -> Verification + Evidence
+  -> Ruflo/RuVector/OmniRoute integrations
+  -> Autonomous Dev + governed swarms
+  -> Cockpit and public launch
+```
+
+Risk, strategy/edge, and backtest integration can proceed in parallel after provider contracts are stable, but they must not block the core authority path.
+
+## Operating Rules
+
+- Use Ruflo as the default swarm/runtime implementation where available, but keep all contracts and enforcement in Verdict.
+- If a provider or swarm is unavailable, continue only with explicitly bounded local defaults or mark the work blocked; never silently weaken policy.
+- Every implementation story must include acceptance criteria, security considerations, tests, evidence, dependencies, and definition of done.
+- Preserve uncommitted user work in every repository; no cleanup or reset without explicit approval.


### PR DESCRIPTION
## Summary\n- add current-state audit across seven Verdict repositories\n- add target architecture gap and implementation-lift analysis\n- add research decisions and phased roadmap\n- defer memory-unification implementation tickets to the active parallel effort\n- add concrete-model qualification and advisory guidance-plugin requirements\n\n## Verification\n- git diff --check\n- source, tests, manifests, ADRs, CI, Code Review Graph, and existing GitHub issues reviewed\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)