### PR TITLE
docs(strategy): ratify evidence-gated AutoDev portfolio direction

### DIFF
--- a/PORTFOLIO_PRODUCT_STRATEGY.md
+++ b/PORTFOLIO_PRODUCT_STRATEGY.md
@@ -1,0 +1,272 @@
+# Verdict Portfolio Product Strategy
+
+**Status:** Superseded pending OmniRoute overlap and market differentiation review  
+**Date:** 2026-08-15  
+**Audience:** contributors, implementation agents, reviewers, interviewers, and potential clients
+
+> **Decision hold (2026-08-15):** OmniRoute already implements task-aware
+> routing, `auto/<category>:<tier>` virtual combos, cost/latency/quota/health
+> scoring, provider fallback, circuit breakers, connection cooldowns, model
+> lockouts, Fusion/pipeline strategies, telemetry, and routing transparency.
+> The routing-first Verdict thesis below must not drive further implementation
+> until the active capability, competitive, and portfolio research establishes
+> a non-duplicative product boundary. Treat the remainder as historical input,
+> not an approved build specification.
+
+> **Leading replacement hypothesis:** Verdict becomes OmniRoute's local-first
+> evidence, authorization, and replay layer: OmniRoute routes and executes;
+> Verdict records route/action receipts, enforces protected-action policy,
+> replays traffic against policy/model changes, and produces CI/audit evidence.
+> This remains under research until the source/runtime capability audit is
+> complete.
+
+## 1. The product hypothesis under review
+
+Verdict Core should solve one clear problem:
+
+> Route each AI request to the least expensive currently available model that
+> satisfies the task's capability, privacy, reliability, and policy
+> requirements, then produce an auditable explanation of the decision.
+
+The near-term product is a **policy-gated, cost-aware model router**. The
+long-term autonomous-AI control-plane vision remains a roadmap, not a claim
+that blocks the first portfolio release.
+
+Verdict's differentiation is not transport alone. Existing gateways already
+forward requests. Verdict owns the enforceable decision boundary:
+
+1. normalize the task and policy;
+2. inspect fresh runtime and capability evidence;
+3. reject ineligible concrete routes before ranking;
+4. select the lowest-cost eligible route;
+5. execute with bounded retries and policy-safe fallback;
+6. emit a receipt that explains the selection and every exclusion;
+7. compare verified success, cost, and latency against a declared baseline.
+
+## 2. Portfolio promise
+
+A visitor should understand Verdict in thirty seconds:
+
+> Teams using multiple AI models either waste money by sending everything to
+> frontier models or accept risk from simplistic cheap-model routing. Verdict
+> filters candidates through hard capability, privacy, budget, availability,
+> and authorization rules, chooses the least-cost eligible route, handles
+> failure safely, and records why the decision was made.
+
+The flagship demonstration must show:
+
+1. a routine task selecting a low-cost route;
+2. a difficult coding task selecting a stronger route;
+3. a protected task rejecting an unverified or disallowed provider;
+4. a forced provider failure followed by an allowed fallback or explicit
+   denial;
+5. the candidate funnel, final receipt, cost, latency, and outcome;
+6. an honest comparison with always-frontier and always-cheap baselines.
+
+Two modes are required:
+
+- **Fixture mode:** deterministic, credential-free, and runnable from a clean
+  checkout.
+- **Live mode:** source-bound to a reachable OmniRoute or other documented
+  OpenAI-compatible runtime, with unavailable runtime state reported as
+  unknown rather than inferred from a catalog.
+
+Fixture measurements must be labelled simulations. Live savings claims require
+published task inputs, provider/model identities, raw results, environment,
+and a reproducible analysis command.
+
+## 3. Architecture and repository ownership
+
+```text
+Application / agent
+        |
+        v
+    Verdict Core
+ policy + eligibility
+ availability + cost
+ route + fallback
+        |
+        v
+ OmniRoute / OpenAI-compatible runtime
+        |
+        v
+ decision receipt + metrics + explanation
+        |
+        v
+  Verdict Cockpit
+```
+
+### verdict-core
+
+The only policy authority and flagship implementation. It owns task/policy
+contracts, capability and availability qualification, eligibility, cost-aware
+selection, bounded execution/fallback, explainability, receipts, fixture/live
+demos, and reproducible benchmarks.
+
+### verdict-node
+
+A thin typed integration layer. It owns the Core client, Express/Next.js
+middleware, OpenAI-compatible forwarding, contract-conformance tests, and one
+runnable example. It must not become a second policy or routing authority.
+
+### verdict-cockpit
+
+The visual portfolio surface. The first useful views are live decisions,
+candidate eligibility/exclusions, provider/model health, and cost/latency/
+fallback/success metrics. Mock trading/order-book behavior is outside the AI
+routing portfolio path.
+
+### verdict-ecosystem
+
+The portfolio landing page and cross-repository compatibility map. It presents
+two separate tracks:
+
+1. AI infrastructure: Core, Node, and Cockpit.
+2. Quantitative systems: Risk, Strategy, and Backtest.
+
+It must link only verified claims and current repository status.
+
+### verdict-core-memory
+
+The shared Codex/Claude memory initiative is abandoned and is not a product
+pillar, integration dependency, or release blocker. The repository should be
+marked experimental/deprecated and removed from the primary portfolio path.
+
+### verdict-risk, verdict-strategy, and verdict-backtest
+
+These form a separate quantitative-systems case study: signal evaluation,
+risk authorization, and Monte Carlo validation. They should not be described as
+runtime components of the AI router.
+
+## 4. Autonomous-development approach
+
+The existing twelve-stage `AutoDevWorkflow` is not accepted as proof of an
+autonomous engineering system merely because it emits stage artifacts. A real
+workflow must bind every completion claim to an observed action and source
+state.
+
+Use this lean execution loop:
+
+1. **Frame** — read the ticket, repository instructions, dirty state, relevant
+   ADRs/contracts, and define measurable acceptance criteria.
+2. **Research and decide** — use a strong model for product, architecture,
+   security, or ambiguous cross-repository decisions; record rejected options
+   and write an ADR only for a durable decision.
+3. **Slice and route** — create bounded work units with exact repository,
+   worktree, file ownership, tests, dependencies, model tier, retry budget, and
+   escalation condition.
+4. **Execute** — assign each writing unit to exactly one writer in an isolated
+   worktree. Prefer deterministic tools and lesser models for mechanical edits,
+   docs, fixtures, focused tests, and straightforward adapters.
+5. **Verify independently** — run focused checks, failure paths, repository
+   regression gates, clean-install/demo smoke, and independent diff review.
+6. **Integrate and receipt** — the parent reconciles source-bound outputs and
+   reports exact evidence. Commit, push, PR, merge, release, or publication only
+   occur when explicitly authorized and the relevant gate is green.
+
+The loop stops at the authorized objective. It does not automatically choose
+and merge the next backlog issue.
+
+### Model allocation policy
+
+| Work | Preferred route | Escalate when |
+|---|---|---|
+| Search, inventory, documentation comparison | OmniRoute free/fast explorer or `cx/gpt-5.4-mini` | evidence conflicts or the decision changes scope |
+| Mechanical edits, fixtures, focused tests, formatting | deterministic tool, free/fast worker, or `cx/gpt-5.4-mini` | two failed attempts or ownership ambiguity |
+| Bounded implementation from an approved spec | cheapest qualified coding route | contract/security implications emerge |
+| Architecture, product scope, security boundaries, integration synthesis | `cx/gpt-5.5` or stronger qualified reasoner | human authority or product choice is required |
+| Independent review | provider-diverse model where available | critical finding needs senior adjudication |
+
+Catalog registration, aliases, and `auto/*` names are not proof of live
+availability. Runtime qualification should precede model assignment. If a
+requested route cannot be verified, use an available lesser route for bounded
+work or escalate; do not silently claim the requested model executed.
+
+### Work-unit contract
+
+Every delegated implementation task must specify:
+
+- objective and acceptance criteria;
+- repository, branch/worktree, and exact write scope;
+- prohibited actions and protected paths;
+- expected tests and evidence commands;
+- model/route class and why it is sufficient;
+- retry/time budget and escalation trigger;
+- required handoff: changed paths, commands/results, limitations, and source
+  state.
+
+One worktree has one writer. Read-only reviewers may share a checkout. The
+integration owner alone changes shared manifests or lockfiles.
+
+## 5. Portfolio release gates
+
+The portfolio release is ready when all of these are true:
+
+- a clean checkout can install and run the fixture demo using documented
+  commands;
+- the live demo either executes through a qualified runtime or fails explicitly
+  as unavailable/unknown;
+- three routing scenarios and one forced-failure scenario produce explainable,
+  privacy-safe receipts;
+- benchmarks compare always-frontier, always-cheap, and Verdict routing on a
+  published fixed task set;
+- cost is reported per verified successful task, with latency, route errors,
+  fallback rate, and policy-denial rate;
+- Core and Node default branches have green required CI and clean-install
+  checks;
+- Node delegates policy to Core and passes contract-conformance tests;
+- Cockpit renders real Core decisions and exclusions;
+- README, repository descriptions, badges, package names, links, screenshots,
+  and status claims agree;
+- unsupported shared-memory, SONA, throughput, latency, and production claims
+  are removed or explicitly labelled experimental;
+- an independent reviewer can reproduce the demo and evidence from the tagged
+  source state.
+
+## 6. Fast execution order
+
+### Phase 0 — credibility repair
+
+- select the authoritative Core branch and reconcile open work;
+- fix Core and Node default-branch CI/security/clean-install failures;
+- fix the clean-checkout fixture demo;
+- align repository descriptions, links, badges, and product terminology;
+- deprecate the shared-memory narrative and remove unsupported claims.
+
+### Phase 1 — real golden path
+
+- implement request -> qualification -> eligibility -> route -> execution ->
+  fallback -> receipt against fixture and live adapters;
+- include policy denial and provider failure paths;
+- freeze Core/Node contracts and add cross-repository conformance tests.
+
+### Phase 2 — evidence
+
+- publish the fixed task set and baselines;
+- run source-bound fixture and live benchmarks;
+- preserve raw evidence and generate a concise case study.
+
+### Phase 3 — presentation
+
+- connect Cockpit to Core;
+- add architecture and decision-funnel visuals;
+- record a three-to-five-minute walkthrough;
+- publish an honest limitations section and a tagged release after approval.
+
+## 7. First delegated workstreams
+
+These streams may run in parallel only in separate worktrees:
+
+1. **Core credibility:** clean-checkout quickstart, demo truthfulness, default
+   branch CI/security root causes.
+2. **Node boundary:** thin-client contract audit, clean-install/lint repairs,
+   duplicated-policy removal plan.
+3. **Cockpit surface:** current-state audit and minimal real-Core dashboard spec.
+4. **Portfolio alignment:** landing-page rewrite, repository status matrix,
+   stale/unsupported claim removal.
+5. **Autodev golden path:** replace synthetic stage-completion claims with the
+   lean work-unit loop and a real small-repository proof, keeping release and
+   external mutation human-authorized.
+
+The parent agent owns architecture, cross-repository integration, evidence
+adjudication, and final release recommendation.

--- a/PORTFOLIO_PRODUCT_STRATEGY.md
+++ b/PORTFOLIO_PRODUCT_STRATEGY.md
@@ -1,272 +1,416 @@
 # Verdict Portfolio Product Strategy
 
-**Status:** Superseded pending OmniRoute overlap and market differentiation review  
-**Date:** 2026-08-15  
+**Status:** Approved product boundary; implementation and release evidence pending
+
+**Date:** 2026-08-15
+
 **Audience:** contributors, implementation agents, reviewers, interviewers, and potential clients
 
-> **Decision hold (2026-08-15):** OmniRoute already implements task-aware
-> routing, `auto/<category>:<tier>` virtual combos, cost/latency/quota/health
-> scoring, provider fallback, circuit breakers, connection cooldowns, model
-> lockouts, Fusion/pipeline strategies, telemetry, and routing transparency.
-> The routing-first Verdict thesis below must not drive further implementation
-> until the active capability, competitive, and portfolio research establishes
-> a non-duplicative product boundary. Treat the remainder as historical input,
-> not an approved build specification.
+## 1. Product decision
 
-> **Leading replacement hypothesis:** Verdict becomes OmniRoute's local-first
-> evidence, authorization, and replay layer: OmniRoute routes and executes;
-> Verdict records route/action receipts, enforces protected-action policy,
-> replays traffic against policy/model changes, and produces CI/audit evidence.
-> This remains under research until the source/runtime capability audit is
-> complete.
+Verdict should become an **evidence-gated autonomous development control
+plane**.
 
-## 1. The product hypothesis under review
+Its promise is:
 
-Verdict Core should solve one clear problem:
+> Autonomous coding tools can produce a patch. Verdict determines whether that
+> exact patch, produced by that exact route from that exact source state, has
+> earned the right to be accepted. It then uses independently verified outcomes
+> to recommend which model or OmniRoute combo should receive similar work next.
 
-> Route each AI request to the least expensive currently available model that
-> satisfies the task's capability, privacy, reliability, and policy
-> requirements, then produce an auditable explanation of the decision.
+This is a control and evaluation product for software changes, not another
+agent framework or model gateway.
 
-The near-term product is a **policy-gated, cost-aware model router**. The
-long-term autonomous-AI control-plane vision remains a roadmap, not a claim
-that blocks the first portfolio release.
+The shared Codex/Claude memory initiative is abandoned. Memory, context
+hydration, and generic knowledge retrieval are not a Verdict product pillar.
 
-Verdict's differentiation is not transport alone. Existing gateways already
-forward requests. Verdict owns the enforceable decision boundary:
+## 2. The problem worth solving
 
-1. normalize the task and policy;
-2. inspect fresh runtime and capability evidence;
-3. reject ineligible concrete routes before ranking;
-4. select the lowest-cost eligible route;
-5. execute with bounded retries and policy-safe fallback;
-6. emit a receipt that explains the selection and every exclusion;
-7. compare verified success, cost, and latency against a declared baseline.
+Teams can already ask coding agents to plan, edit, test, review, and open pull
+requests. The hard problem is deciding when their output is trustworthy:
 
-## 2. Portfolio promise
+- the model reported success, but did the declared verification actually run?
+- did the patch stay inside its work-unit ownership and policy envelope?
+- was the selected route really available and qualified for the required tools?
+- does the evidence belong to the exact commit and dirty-tree state being reviewed?
+- was a cheaper model genuinely successful on this category of task, or merely fast?
+- can a route policy be changed without letting learned ranking bypass hard safety rules?
+- can a reviewer reproduce why a change or route promotion was allowed?
 
-A visitor should understand Verdict in thirty seconds:
+Verdict should answer these questions with an enforceable development contract
+and source-bound evidence, then fail closed when a required fact is unknown.
 
-> Teams using multiple AI models either waste money by sending everything to
-> frontier models or accept risk from simplistic cheap-model routing. Verdict
-> filters candidates through hard capability, privacy, budget, availability,
-> and authorization rules, chooses the least-cost eligible route, handles
-> failure safely, and records why the decision was made.
+## 3. Ecosystem boundary
 
-The flagship demonstration must show:
+The portfolio is credible only if each project owns a distinct layer.
 
-1. a routine task selecting a low-cost route;
-2. a difficult coding task selecting a stronger route;
-3. a protected task rejecting an unverified or disallowed provider;
-4. a forced provider failure followed by an allowed fallback or explicit
-   denial;
-5. the candidate funnel, final receipt, cost, latency, and outcome;
-6. an honest comparison with always-frontier and always-cheap baselines.
+| System | Reuse it for | Verdict must not duplicate |
+|---|---|---|
+| **OmniRoute** | provider/model transport, live discovery, task-aware combos, cost/latency/quota/health scoring, fallback, circuit breakers, usage analytics, and eval-assisted target ordering | provider adapters, generic model scoring, static task-fitness tables, combo execution, gateway analytics, or transport failover |
+| **Ruflo** | orchestration, swarms, workflows, hooks, memory, worker lifecycle, generic proof envelopes, and coordination ledgers | another swarm runtime, generic workflow engine, shared agent memory, or general-purpose proof ledger |
+| **Codex/Claude/other workers** | planning, coding, review, and bounded command execution | another coding model or IDE agent experience |
+| **Git and CI** | immutable commits, diffs, tests, checks, and deployment status | source hosting or a replacement CI runner |
+| **Verdict** | deterministic task/role eligibility, protected-effect policy, source-state binding, independent acceptance evidence, outcome evaluation, counterfactual comparison, and gated route-policy promotion | everything in the columns above |
 
-Two modes are required:
-
-- **Fixture mode:** deterministic, credential-free, and runnable from a clean
-  checkout.
-- **Live mode:** source-bound to a reachable OmniRoute or other documented
-  OpenAI-compatible runtime, with unavailable runtime state reported as
-  unknown rather than inferred from a catalog.
-
-Fixture measurements must be labelled simulations. Live savings claims require
-published task inputs, provider/model identities, raw results, environment,
-and a reproducible analysis command.
-
-## 3. Architecture and repository ownership
+The concise division is:
 
 ```text
-Application / agent
-        |
-        v
-    Verdict Core
- policy + eligibility
- availability + cost
- route + fallback
-        |
-        v
- OmniRoute / OpenAI-compatible runtime
-        |
-        v
- decision receipt + metrics + explanation
-        |
-        v
-  Verdict Cockpit
+Ruflo coordinates the work.
+OmniRoute finds and serves the route.
+Workers produce the change.
+Git and CI provide source and check evidence.
+Verdict decides what that evidence is allowed to authorize.
 ```
+
+## 4. Capability audit method
+
+Portfolio claims use four distinct evidence states:
+
+1. **Documented** — a guide or design says the capability exists.
+2. **Source-implemented** — a named branch, commit, or tagged source snapshot contains an executable path and tests.
+3. **Live-configured** — the installed runtime is configured to expose the path.
+4. **Behaviorally verified** — a current probe exercised the path and retained evidence.
+
+No lower state implies a higher one. Catalog entries, aliases, configuration,
+and test fixtures are not runtime proof.
+
+### Current overlap matrix
+
+This matrix is intentionally conservative. `Yes` means evidence for that state
+was found during the 2026-08-15 review and must name the branch, commit,
+runtime, or retained probe evidence. `Partial` means the adjacent capability
+exists but not the complete portfolio behavior; `no finding` is not a claim of
+impossibility.
+
+| Capability | OmniRoute | Ruflo | Verdict | Portfolio decision |
+|---|---|---|---|---|
+| Task/category routing | documented and source-implemented; live health verified, route behavior not re-verified in this review | documented and source-implemented | eligibility/ranking foundations implemented | **Reuse OmniRoute** |
+| Cost, latency, quota, health, fallback | documented and source-implemented; health endpoint verified | partial orchestration overlap | partial adapters and policy inputs | **Reuse OmniRoute** |
+| Eval-driven target reordering | source-implemented and wired behind configuration | candidate comparison exists | evaluation reports exist | **Reuse OmniRoute execution; Verdict consumes results as evidence** |
+| Analytics-derived combo recommendation from verified development outcomes | no complete closed loop found | task-bucket and candidate-learning pieces, but gaps remain in per-model selection use | evaluation and promotion primitives exist, not an integrated AutoDev loop | **Extend Verdict at the acceptance boundary** |
+| Generic agent orchestration and workflows | cloud-agent/bridge surfaces exist | documented and source-implemented | two AutoDev paths exist, one largely synthetic | **Reuse Ruflo/workers; do not build another generic orchestrator** |
+| Real bounded patch execution | agent dispatch exists | worker execution exists | CLI-wired work units, patch boundaries, verification, and durable outcomes exist on the unmerged `feat/autodev-v0.1` branch | **Extend Verdict's real AutoDev runner after integration review** |
+| Generic proof envelope or ledger | audits and retained eval artifacts exist | HMAC proof envelopes, hash chaining, and durable run ledger exist | durable receipt chains exist | **Do not sell receipts alone** |
+| Exact source/work-unit acceptance contract | partial audit artifacts | partial proof and policy gates | owned-file enforcement and verification receipts exist; full immutable source snapshot binding needs integration | **Verdict flagship boundary** |
+| Protected-effect authorization | management/auth/guardrails exist | guidance gates exist | deterministic allow/deny/unknown and policy transitions exist | **Verdict owns development-specific authorization** |
+| Counterfactual route replay | reasoning/eval replay pieces exist | comparison harnesses exist | replay-only counterfactuals cannot authorize promotion | **Extend Verdict's authority separation** |
+| Shadow/candidate/canary/active route lifecycle | release and routing controls exist, but no complete development-outcome promotion loop was found | promotion/learning pieces exist | source and tests exist on the unmerged AutoDev branch with kill switch, degradation, quarantine, and rollback; no live end-to-end proof | **Integrate and behaviorally verify before marketing** |
+| CI regression authority | CI/release gates exist | validation workflows exist | evidence contracts exist, but end-to-end CI-bound acceptance is incomplete | **Verdict consumes CI evidence and decides authorization** |
+
+Important audit corrections:
+
+- OmniRoute already provides far more than transport: `auto/*` category/tier
+  combos, task fitness, eval-driven target ordering, analytics, health, quota,
+  fallback, and multiple agent protocols. A routing-first Verdict would be a
+  weaker duplicate.
+- Ruflo already provides broad orchestration, model routing, workflows,
+  learning, proof envelopes, ledgers, and governance. An AutoDev framework or
+  receipt-ledger-first Verdict would also be a duplicate.
+- Verdict feature branches already contain unusually useful primitives:
+  fail-closed eligibility,
+  capability passports, durable receipts, a real bounded patch runner,
+  independently verified evaluation observations, replay-only
+  counterfactuals, and gated route lifecycle transitions. These capabilities
+  are not all present on the current default branch. The portfolio work is to
+  review and integrate the smallest coherent subset into one honest end-to-end
+  product.
+
+## 5. Flagship product: Verdict AutoDev Route Lab
+
+The first product slice should be **AutoDev Route Lab**, a local-first workflow
+that evaluates and governs model/combo policies for software-development task
+categories using verified repository outcomes.
+
+### Input contract
+
+Each run begins with:
+
+- an objective and task category;
+- repository and immutable source-state identity;
+- bounded work units with exact owned paths;
+- required capabilities and role policy;
+- allowed effects, commands, spend, retries, and escalation rules;
+- candidate concrete routes or OmniRoute combos;
+- acceptance commands and independent evidence requirements.
+
+### Runtime flow
+
+```text
+Objective + source snapshot
+          |
+          v
+Bounded work-unit contract
+          |
+          v
+Fresh route discovery from OmniRoute
+          |
+          v
+Verdict deterministic eligibility and protected-effect gate
+          |
+          v
+Ruflo/Codex/Claude worker execution in an isolated scope
+          |
+          v
+Independent diff-boundary, test, policy, and CI verification
+          |
+          v
+Tamper-evident acceptance bundle bound to source + route + outcome
+          |
+          v
+Per-category Route Lab comparison and recommendation
+          |
+          v
+Shadow -> candidate -> canary -> active, or quarantine/rollback
+```
+
+Learned ranking and analytics may reorder only routes that deterministic
+eligibility already admitted. A recommendation cannot mutate source, promote a
+route, or publish an artifact. Those remain separate protected actions.
+
+### Output contract
+
+One run produces a redacted, portable report answering:
+
+- what objective and source snapshot were evaluated;
+- which work units and effects were authorized;
+- which routes were considered, excluded, requested, selected, and actually served;
+- what files changed and whether ownership boundaries held;
+- what tests, checks, and reviews ran, with exit status and artifact digests;
+- whether the change is accepted, denied, or unknown, and why;
+- measured latency, token usage, cost when available, and failure class;
+- whether the observation is eligible for learning or promotion;
+- what route-policy change is recommended, with confidence and limitations.
+
+The portfolio-facing name for this artifact is a **Trusted Change Report**.
+
+## 6. The 3–5 minute portfolio demonstration
+
+The demo must be understandable without credentials and impressive with a live
+runtime.
+
+### Fixture scenario
+
+Use a small versioned repository containing a realistic failing API
+authorization test and one protected file outside the task boundary.
+
+1. Show the objective: fix the authorization bug without modifying the policy
+   definition or weakening tests.
+2. Show fresh candidate qualification and why an unverified route is excluded.
+3. Dispatch a bounded implementation to a cheap `cx/gpt-*` route through
+   OmniRoute. If fixture mode is used, label the recorded worker responses as
+   deterministic fixtures.
+4. Demonstrate one rejected candidate patch that edits a protected file or
+   weakens a test. The worker's self-reported success does not matter.
+5. Demonstrate one accepted patch whose diff stays in bounds and whose focused
+   tests plus independent regression check pass.
+6. Open the Trusted Change Report: exact source, requested/actual route, policy
+   decisions, diff, checks, costs/tokens when measured, and receipt integrity.
+7. Show Route Lab comparing verified outcomes for a cheaper route and a stronger
+   route in this task category. It recommends shadow/candidate promotion but
+   cannot promote itself.
+8. Trigger a regression observation and show quarantine or rollback.
+
+The closing sentence should be:
+
+> OmniRoute made model choice operational and Ruflo made agents operational.
+> Verdict makes accepting and learning from autonomous changes governable.
+
+### Live mode
+
+Live mode uses qualified concrete `cx/gpt-*` routes through OmniRoute and
+records the requested, selected, and actually served identities. If the runtime
+cannot prove availability, identity, or required capabilities, the run reports
+`unknown` or denies the protected action. It never silently substitutes a
+catalog claim.
+
+## 7. Marketability standard
+
+A visitor should understand the project at three depths.
+
+### Thirty-second skim
+
+- one sentence describing the trust problem;
+- one architecture diagram showing the ecosystem boundary;
+- one screenshot of an accepted and rejected autonomous change;
+- one command that runs the credential-free demo;
+- explicit status and limitations.
+
+### Three-to-five-minute review
+
+- the fixture walkthrough above;
+- a Trusted Change Report that can be inspected without a running service;
+- a visible deny path, not only a successful happy path;
+- a route recommendation backed by independently verified outcomes;
+- a clear explanation of why the recommendation cannot self-authorize.
+
+### Deep technical review
+
+- versioned contracts and JSON schemas;
+- threat model and authorization invariants;
+- deterministic fixture data plus optional source-bound live evidence;
+- tests for stale/unknown state, tampering, boundary escape, route mismatch,
+  forged promotion, and rollback;
+- architecture decision records that explicitly assign OmniRoute, Ruflo, Git,
+  CI, and Verdict ownership;
+- reproducible benchmark inputs and honest methodology.
+
+Avoid vanity provider/model counts, generated dashboards without a real data
+path, synthetic success labelled as a benchmark, unsupported performance
+claims, giant feature lists, and an autonomous system whose only evidence is
+its own completion message.
+
+## 8. Repository roles
 
 ### verdict-core
 
-The only policy authority and flagship implementation. It owns task/policy
-contracts, capability and availability qualification, eligibility, cost-aware
-selection, bounded execution/fallback, explainability, receipts, fixture/live
-demos, and reproducible benchmarks.
+The flagship authority and implementation. It owns work-unit contracts,
+deterministic eligibility, capability/runtime passports, protected-effect
+policy, source-bound evidence, acceptance decisions, outcome evaluation,
+counterfactual authority separation, and promotion/quarantine rules.
 
 ### verdict-node
 
-A thin typed integration layer. It owns the Core client, Express/Next.js
-middleware, OpenAI-compatible forwarding, contract-conformance tests, and one
-runnable example. It must not become a second policy or routing authority.
+A thin typed client and integration layer. It should expose Core contracts to
+Node/Express/Next.js users and pass cross-language conformance tests. It must
+not implement a second policy engine, route learner, or receipt authority.
 
 ### verdict-cockpit
 
-The visual portfolio surface. The first useful views are live decisions,
-candidate eligibility/exclusions, provider/model health, and cost/latency/
-fallback/success metrics. Mock trading/order-book behavior is outside the AI
-routing portfolio path.
+The visual inspection surface for Trusted Change Reports and Route Lab. Its
+first views should be run timeline, work-unit status, candidate funnel,
+diff/check evidence, route comparison, and promotion/quarantine state. It
+should render fixture data through the same contracts as live data.
 
 ### verdict-ecosystem
 
-The portfolio landing page and cross-repository compatibility map. It presents
-two separate tracks:
-
-1. AI infrastructure: Core, Node, and Cockpit.
-2. Quantitative systems: Risk, Strategy, and Backtest.
-
-It must link only verified claims and current repository status.
+The portfolio landing page, compatibility map, demo guide, and evidence index.
+It should distinguish verified-current, fixture-only, experimental, and roadmap
+claims.
 
 ### verdict-core-memory
 
-The shared Codex/Claude memory initiative is abandoned and is not a product
-pillar, integration dependency, or release blocker. The repository should be
-marked experimental/deprecated and removed from the primary portfolio path.
+Archived or experimental only. It is not part of the flagship narrative,
+installation path, architecture diagram, or release gate.
 
 ### verdict-risk, verdict-strategy, and verdict-backtest
 
-These form a separate quantitative-systems case study: signal evaluation,
-risk authorization, and Monte Carlo validation. They should not be described as
-runtime components of the AI router.
+A separate quantitative-systems case study. Preserve it as evidence of policy,
+risk, and evaluation engineering, but do not present it as a dependency of the
+autonomous-development product.
 
-## 4. Autonomous-development approach
+## 9. Fastest credible delivery plan
 
-The existing twelve-stage `AutoDevWorkflow` is not accepted as proof of an
-autonomous engineering system merely because it emits stage artifacts. A real
-workflow must bind every completion claim to an observed action and source
-state.
+### Phase 0 — preserve credibility
 
-Use this lean execution loop:
+- keep the already-pushed credential-free Core quickstart repair;
+- align this landing page and every primary README to the approved product boundary;
+- remove or qualify routing-first, shared-memory, SONA, provider-count, package,
+  benchmark, and production claims that lack current evidence;
+- identify the authoritative Core branch before integrating any old worktree.
 
-1. **Frame** — read the ticket, repository instructions, dirty state, relevant
-   ADRs/contracts, and define measurable acceptance criteria.
-2. **Research and decide** — use a strong model for product, architecture,
-   security, or ambiguous cross-repository decisions; record rejected options
-   and write an ADR only for a durable decision.
-3. **Slice and route** — create bounded work units with exact repository,
-   worktree, file ownership, tests, dependencies, model tier, retry budget, and
-   escalation condition.
-4. **Execute** — assign each writing unit to exactly one writer in an isolated
-   worktree. Prefer deterministic tools and lesser models for mechanical edits,
-   docs, fixtures, focused tests, and straightforward adapters.
-5. **Verify independently** — run focused checks, failure paths, repository
-   regression gates, clean-install/demo smoke, and independent diff review.
-6. **Integrate and receipt** — the parent reconciles source-bound outputs and
-   reports exact evidence. Commit, push, PR, merge, release, or publication only
-   occur when explicitly authorized and the relevant gate is green.
+### Phase 1 — one vertical contract
 
-The loop stops at the authorized objective. It does not automatically choose
-and merge the next backlog issue.
+- define versioned work-unit, source-state, route-decision, verification, Trusted
+  Change Report, and route-recommendation schemas;
+- connect the real `verdict autodev` runner to capability passports,
+  deterministic eligibility, and evaluation receipts;
+- bind dirty-tree state as an immutable snapshot rather than using `HEAD` alone;
+- classify operational failures separately from code-quality failures;
+- ensure counterfactual observations and recommendations cannot authorize
+  mutation or promotion.
 
-### Model allocation policy
+### Phase 2 — reproducible demo
 
-| Work | Preferred route | Escalate when |
-|---|---|---|
-| Search, inventory, documentation comparison | OmniRoute free/fast explorer or `cx/gpt-5.4-mini` | evidence conflicts or the decision changes scope |
-| Mechanical edits, fixtures, focused tests, formatting | deterministic tool, free/fast worker, or `cx/gpt-5.4-mini` | two failed attempts or ownership ambiguity |
-| Bounded implementation from an approved spec | cheapest qualified coding route | contract/security implications emerge |
-| Architecture, product scope, security boundaries, integration synthesis | `cx/gpt-5.5` or stronger qualified reasoner | human authority or product choice is required |
-| Independent review | provider-diverse model where available | critical finding needs senior adjudication |
+- add the small authorization-bug fixture repository and recorded provider fixtures;
+- produce accepted, rejected, stale-evidence, regression, and rollback reports;
+- add one command that generates all fixture evidence from a clean checkout;
+- add an optional live command using qualified `cx/gpt-*` routes.
 
-Catalog registration, aliases, and `auto/*` names are not proof of live
-availability. Runtime qualification should precede model assignment. If a
-requested route cannot be verified, use an available lesser route for bounded
-work or escalate; do not silently claim the requested model executed.
+### Phase 3 — Route Lab and Cockpit
 
-### Work-unit contract
+- aggregate independently verified outcomes by task category and exact route;
+- compare success, quality, latency, token usage, cost, and operational failures;
+- emit advisory combo/route recommendations with sample size and confidence;
+- gate route lifecycle transitions through existing
+  `shadow -> candidate -> canary -> active` policy;
+- render the exact same report and recommendation contracts in Cockpit.
 
-Every delegated implementation task must specify:
+### Phase 4 — portfolio conversion
 
-- objective and acceptance criteria;
-- repository, branch/worktree, and exact write scope;
+- publish the architecture boundary, threat model, benchmark methodology, and
+  limitations;
+- capture one concise screenshot set and a three-to-five-minute walkthrough;
+- run clean-install, full regression, security, schema-conformance, and demo
+  reproduction checks against the exact release source;
+- tag or release only after explicit authorization and green independent evidence.
+
+## 10. Autonomous delivery policy
+
+Research, architecture, security, and cross-repository decisions use the
+strongest qualified reasoning route available. Once a contract is approved,
+bounded implementation, fixtures, focused tests, formatting, and documentation
+use the cheapest qualified worker.
+
+For GPT workers, requests use the OmniRoute-facing `cx/gpt-*` identity, such as
+`cx/gpt-5.4-mini` or `cx/gpt-5.5`. A native worker API may normalize that to an
+unprefixed model name; reports must preserve the requested route separately
+from the actual served identity rather than claiming the prefix was executed.
+
+Every delegated work unit specifies:
+
+- objective and measurable acceptance criteria;
+- repository, isolated worktree, and exact write ownership;
 - prohibited actions and protected paths;
-- expected tests and evidence commands;
-- model/route class and why it is sufficient;
-- retry/time budget and escalation trigger;
-- required handoff: changed paths, commands/results, limitations, and source
-  state.
+- model/route class and escalation condition;
+- focused and integration checks;
+- required source-bound handoff evidence.
 
-One worktree has one writer. Read-only reviewers may share a checkout. The
-integration owner alone changes shared manifests or lockfiles.
+One worktree has one writer. The integration owner alone changes shared
+manifests or lockfiles. Read-only reviewers may share a checkout. When the
+repository owner has authorized commit and push, atomic safe slices are pushed
+immediately because the development host is disposable. No merge, release,
+publication, destructive action, or protected promotion is implied by
+permission to implement and push a feature branch.
 
-## 5. Portfolio release gates
+## 11. Portfolio release gate
 
-The portfolio release is ready when all of these are true:
+The flagship is ready to present when:
 
-- a clean checkout can install and run the fixture demo using documented
-  commands;
-- the live demo either executes through a qualified runtime or fails explicitly
-  as unavailable/unknown;
-- three routing scenarios and one forced-failure scenario produce explainable,
-  privacy-safe receipts;
-- benchmarks compare always-frontier, always-cheap, and Verdict routing on a
-  published fixed task set;
-- cost is reported per verified successful task, with latency, route errors,
-  fallback rate, and policy-denial rate;
-- Core and Node default branches have green required CI and clean-install
-  checks;
-- Node delegates policy to Core and passes contract-conformance tests;
-- Cockpit renders real Core decisions and exclusions;
-- README, repository descriptions, badges, package names, links, screenshots,
-  and status claims agree;
-- unsupported shared-memory, SONA, throughput, latency, and production claims
-  are removed or explicitly labelled experimental;
-- an independent reviewer can reproduce the demo and evidence from the tagged
-  source state.
+- a clean checkout runs the credential-free demo with one documented command;
+- the same versioned contracts support fixture and optional live modes;
+- at least one accepted and one denied change are reproducible;
+- source identity includes tracked and untracked changes or requires a clean commit;
+- requested, selected, and actual route identities are retained;
+- worker self-report is never sufficient verification;
+- stale, unknown, mismatched, or tampered evidence fails closed;
+- operational failures are not scored as model-quality failures;
+- route recommendations show sample size, confidence, and limitations;
+- counterfactual evidence cannot authorize learning, mutation, or promotion;
+- promotion and rollback paths are independently tested;
+- Cockpit renders real report contracts rather than bespoke mock shapes;
+- Core and Node pass clean-install and contract-conformance checks;
+- the README, screenshots, demo, schemas, CI, and release tag describe the same behavior;
+- an independent reviewer can reproduce every primary claim from the tagged source.
 
-## 6. Fast execution order
+## 12. Immediate implementation slices
 
-### Phase 0 — credibility repair
+After this strategy is committed, the next work should be specified and
+dispatched in this order:
 
-- select the authoritative Core branch and reconcile open work;
-- fix Core and Node default-branch CI/security/clean-install failures;
-- fix the clean-checkout fixture demo;
-- align repository descriptions, links, badges, and product terminology;
-- deprecate the shared-memory narrative and remove unsupported claims.
+1. **Contract gap audit:** map existing Core types to the vertical report and
+   identify the smallest schema additions.
+2. **Source-state binding:** define and test clean-commit and dirty-snapshot
+   identities for AutoDev runs.
+3. **Eligibility integration:** make the real AutoDev runner consume fresh
+   passports and deterministic route decisions before worker execution.
+4. **Trusted Change Report:** project existing receipts, verification, and
+   route evidence into one portable redacted report.
+5. **Fixture demo:** generate accepted, rejected, and rollback paths using the
+   production contracts.
+6. **Route Lab recommendation:** aggregate verified outcomes by task category
+   and emit advisory recommendations that cannot self-promote.
+7. **Cockpit adapter:** render the report and route lifecycle without adding
+   policy logic to the UI.
 
-### Phase 1 — real golden path
-
-- implement request -> qualification -> eligibility -> route -> execution ->
-  fallback -> receipt against fixture and live adapters;
-- include policy denial and provider failure paths;
-- freeze Core/Node contracts and add cross-repository conformance tests.
-
-### Phase 2 — evidence
-
-- publish the fixed task set and baselines;
-- run source-bound fixture and live benchmarks;
-- preserve raw evidence and generate a concise case study.
-
-### Phase 3 — presentation
-
-- connect Cockpit to Core;
-- add architecture and decision-funnel visuals;
-- record a three-to-five-minute walkthrough;
-- publish an honest limitations section and a tagged release after approval.
-
-## 7. First delegated workstreams
-
-These streams may run in parallel only in separate worktrees:
-
-1. **Core credibility:** clean-checkout quickstart, demo truthfulness, default
-   branch CI/security root causes.
-2. **Node boundary:** thin-client contract audit, clean-install/lint repairs,
-   duplicated-policy removal plan.
-3. **Cockpit surface:** current-state audit and minimal real-Core dashboard spec.
-4. **Portfolio alignment:** landing-page rewrite, repository status matrix,
-   stale/unsupported claim removal.
-5. **Autodev golden path:** replace synthetic stage-completion claims with the
-   lean work-unit loop and a real small-repository proof, keeping release and
-   external mutation human-authorized.
-
-The parent agent owns architecture, cross-repository integration, evidence
-adjudication, and final release recommendation.
+Each slice should land as a small conventional commit on an isolated branch and
+be pushed as soon as its focused verification passes.

--- a/README.md
+++ b/README.md
@@ -1,154 +1,194 @@
-# Verdict Ecosystem — Policy-Gated LLM Routing Control Plane
+# Verdict Portfolio — Governed Autonomy for Software Teams
 
-> **The gate rules on each task** — deterministic safety verdicts, availability-aware routing, quantitative-trading-grade execution, closed-loop telemetry.
+> **Verdict is the policy and evidence layer for autonomous coding agents.**
+> It determines whether an exact change, produced from an exact source state by
+> an exact route, has earned the right to be accepted.
 
----
+## The problem
 
-## Repository Map
+Coding agents can already plan, edit, test, and open pull requests. Their own
+“task completed” message is not trustworthy evidence that:
 
-| Repo | Purpose | Language | Status |
-|------|---------|----------|--------|
-| [`verdict-core`](https://github.com/mrnicholasbcarter-code/verdict-core) | Python control plane (flagship) | Python | ✅ 321 tests |
-| [`verdict-node`](https://github.com/mrnicholasbcarter-code/verdict-node) | Express/Next.js middleware (`@bodanglin/verdict-node`) | TypeScript | ✅ 169 tests |
-| [`verdict-cockpit`](https://github.com/verdict/verdict-cockpit) | Next.js dashboard | TypeScript | 🚧 |
-| [`verdict-risk`](https://github.com/verdict/verdict-risk) | Zero-allocation risk engine | Python | 🚧 |
-| [`verdict-edge`](https://github.com/verdict/verdict-edge) | Edge mining framework | Python | 🚧 |
-| [`verdict-backtest`](https://github.com/verdict/verdict-backtest) | Monte Carlo harness | Python | 🚧 |
-| `verdict` | Umbrella/meta repo | — | 🚧 |
+- the required checks actually ran;
+- the patch stayed inside its authorized files and effects;
+- the selected model was live and qualified for the task;
+- the evidence belongs to the exact source being reviewed;
+- a cheaper route is genuinely good for this task category;
+- a learned recommendation is allowed to change production policy.
 
----
+Verdict turns those questions into a fail-closed development contract and a
+portable **Trusted Change Report**.
 
-## What is Verdict?
+This is not another router. It is the acceptance authority after a route
+produces a patch.
 
-Verdict is a **policy-gated, availability-aware LLM routing control plane** — not a simple proxy. It provides:
+## Flagship: AutoDev Route Lab
 
-- **Deterministic safety floors**: Hard gate checks (capability, budget, privacy, availability) run locally before any upstream call
-- **Availability-aware routing**: Bounded cache with stale-while-revalidate, explicit `unknown`/`error` states, concurrent refresh deduplication
-- **Explainability first**: `GET /v1/route/explain` surfaces observed_at, expires_at, age, source, confidence, candidate/eligible counts, per-candidate exclusion reasons, cache refresh/error state
-- **Quantitative-trading-grade execution**: Monte Carlo backtest harness, capacity admission with deterministic effort reservations, conservative runtime headroom
-- **Closed-loop telemetry**: SONA feedback loop feeds outcomes (latency, success, cost) back to RuVector for continuous MoE ranking improvement
+The portfolio's first vertical product evaluates and governs model or combo
+policies for software-development tasks using independently verified repository
+outcomes.
 
----
-
-## Quick Start
-
-```bash
-# Install Python control plane
-pipx install verdict-core
-
-# Or with server extras
-pipx install 'verdict-core[server]'
-
-# Configure
-verdict setup
-
-# Route a task
-verdict route "Refactor this Python module to use type hints" --terse
+```text
+Objective + source snapshot
+          |
+          v
+Bounded work-unit contract
+          |
+          v
+OmniRoute discovery and execution
+          |
+          v
+Verdict eligibility + protected-effect policy
+          |
+          v
+Ruflo/Codex/Claude worker
+          |
+          v
+Independent diff, test, policy, and CI evidence
+          |
+          v
+Trusted Change Report
+          |
+          v
+Advisory route recommendation
+          |
+          v
+shadow -> candidate -> canary -> active
+          or quarantine / rollback
 ```
 
----
+The important constraint is that learned ranking and analytics may reorder only
+routes that deterministic eligibility already admitted. A recommendation,
+counterfactual, or worker self-report cannot authorize mutation, promotion, or
+release.
 
-## OmniRoute Integration
+## Ecosystem boundary
 
-Verdict integrates natively with **OmniRoute** (`http://localhost:20128/v1`) for:
-- **3,318+ models** across **250+ providers**
-- **107+ free tiers** — no API keys needed
-- Auto-fallback, RTK compression (15–95% token savings)
-- Smart routing: `auto/best-coding`, `auto/best-reasoning`, `auto/best-fast`
+Verdict deliberately reuses the existing stack:
 
-```bash
-# Start OmniRoute
-docker run -d -p 20128:20128 omnibus/omniroute
+| System | Owns |
+|---|---|
+| [OmniRoute](https://github.com/diegosouzapw/OmniRoute) | provider/model transport, live discovery, task-aware combos, telemetry, scoring, fallback, and circuit breakers |
+| [Ruflo](https://github.com/ruvnet/ruflo) | orchestration, swarms, workflows, hooks, memory, worker lifecycle, and generic proof ledgers |
+| Codex, Claude, and other workers | planning, coding, review, and bounded command execution |
+| Git and CI | immutable source, diffs, checks, and build evidence |
+| **Verdict** | deterministic eligibility, protected-effect policy, source-state binding, acceptance evidence, outcome evaluation, and gated route-policy lifecycle |
 
-# Configure Verdict
-export OMNIROUTE_BASE_URL=http://localhost:20128
-verdict serve
-```
+In one line:
 
----
+> Ruflo coordinates, OmniRoute serves, workers change code, Git and CI provide
+> evidence, and Verdict decides what that evidence may authorize.
 
-## Architecture
+## Repositories
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        VERDICT CORE                              │
-├─────────────────────────────────────────────────────────────────┤
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
-│  │   Gate      │  │ Eligibility │  │ Intelligence│              │
-│  │  (Policy)   │──▶│  (Filter)   │──▶│  (Ranking)  │              │
-│  └─────────────┘  └─────────────┘  └─────────────┘              │
-│         │               │               │                        │
-│         ▼               ▼               ▼                        │
-│  ┌─────────────────────────────────────────────────┐             │
-│  │          Availability Cache (SWR)                │             │
-│  │  TTL + stale-window, explicit unknown/error,     │             │
-│  │  isolation by provider/model/policy-version      │             │
-│  └─────────────────────────────────────────────────┘             │
-└─────────────────────────────────────────────────────────────────┘
-```
+### AI development control plane
 
-### Core Components
+| Repository | Role |
+|---|---|
+| [`verdict-core`](https://github.com/mrnicholasbcarter-code/verdict-core) | Flagship policy and evidence authority: work units, eligibility, passports, receipts, evaluation, promotion, quarantine, and rollback |
+| [`verdict-node`](https://github.com/mrnicholasbcarter-code/verdict-node) | Thin typed client and Express/Next.js integration; no duplicate policy engine |
+| [`verdict-cockpit`](https://github.com/mrnicholasbcarter-code/verdict-cockpit) | Visual inspection of Trusted Change Reports, candidate funnels, verification, route comparisons, and lifecycle state |
+| [`verdict-ecosystem`](https://github.com/mrnicholasbcarter-code/verdict-ecosystem) | This portfolio map, demo guide, and evidence index |
 
-| Module | Purpose |
-|--------|---------|
-| `verdict.gate` | Deterministic policy enforcement — capability, budget, privacy, capacity |
-| `verdict.eligibility` | Availability-aware filtering with explicit unknown handling |
-| `verdict.intelligence` | Advisory ranking (cannot bypass hard gate) |
-| `verdict.availability_cache` | Bounded SWR cache, `explain_freshness()` for `/v1/route/explain` |
-| `verdict.omniroute` | Native OmniRoute transport (250+ providers, 90+ free tiers) |
-| `verdict.contracts` | Versioned Pydantic contracts for all public APIs |
+### Separate quantitative-systems case study
 
----
+| Repository | Role |
+|---|---|
+| [`verdict-risk`](https://github.com/mrnicholasbcarter-code/verdict-risk) | risk authorization and position sizing |
+| [`verdict-strategy`](https://github.com/mrnicholasbcarter-code/verdict-strategy) | strategy composition and validation |
+| [`verdict-backtest`](https://github.com/mrnicholasbcarter-code/verdict-backtest) | reproducible and Monte Carlo validation |
 
-## Ecosystem Integration
+The quantitative repositories demonstrate policy, risk, and evaluation
+engineering. They are not runtime dependencies of AutoDev Route Lab.
 
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                         VERDICT ECOSYSTEM                           │
-├──────────────┬──────────────┬──────────────┬──────────────────────┤
-│  verdict     │  verdict     │  verdict     │  verdict             │
-│  -core       │  -node       │  -cockpit    │  -risk               │
-│  (Python)    │  (TypeScript)│  (Next.js)   │  (Python)            │
-│  Control     │  Middleware  │  Dashboard   │  Risk Engine         │
-│  Plane       │  Express/    │  Visualizer  │  Drawdown/           │
-│              │  Next.js     │              │  Position Sizing     │
-├──────────────┼──────────────┼──────────────┼──────────────────────┤
-│  verdict     │  verdict     │  RuVector    │  Ruflo               │
-│  -edge       │  -backtest   │  (Vector DB) │  (Agent Orch)        │
-│  (Python)    │  (Python)    │  Semantic    │  Swarms/             │
-│  Edge Mining │  Monte Carlo │  Search +    │  Hive Mind           │
-│  Framework   │  Harness     │  Graph RAG   │                      │
-└──────────────┴──────────────┴──────────────┴──────────────────────┘
-```
+`verdict-core-memory` is archived or experimental. The shared Codex/Claude
+memory initiative is abandoned and is not a portfolio pillar, installation
+dependency, or release blocker.
 
----
+## Portfolio demonstration
+
+The intended credential-free demo uses a small repository with a failing API
+authorization test and a protected policy file:
+
+1. Verdict binds the objective to an immutable source snapshot and bounded work
+   units.
+2. Fresh route qualification excludes a stale or unverified candidate.
+3. One candidate patch is denied because it edits a protected file or weakens a
+   test, regardless of the worker's success claim.
+4. A second patch stays in bounds and passes focused plus independent regression
+   checks.
+5. The Trusted Change Report shows requested, selected, and actual route;
+   source identity; policy decisions; diff; checks; failure class; latency; and
+   measured usage/cost when available.
+6. Route Lab compares verified outcomes by task category and recommends a
+   shadow or candidate transition without promoting itself.
+7. A regression observation demonstrates quarantine or rollback.
+
+Fixture provider responses are labelled simulations. Live mode uses qualified
+concrete `cx/gpt-*` routes through OmniRoute and reports unavailable or
+unprovable runtime state as `unknown`.
+
+## Demo command
+
+Not available yet. The release gate requires one credential-free command from
+a clean checkout that produces accepted, denied, route-recommendation, and
+rollback reports. This placeholder must be replaced with the verified command
+before the portfolio is described as presentable.
+
+## Evidence status
+
+The current repositories already contain useful primitives, but the integrated
+flagship demo is still in development.
+
+| Capability | Current evidence |
+|---|---|
+| Fail-closed model eligibility and capability passports | Evidence reported across Core branches; not yet reconciled into one default-branch release claim |
+| Durable receipt chains and integrity checks | Evidence reported across Core branches; not yet reconciled into one default-branch release claim |
+| Real bounded AutoDev patch execution and owned-file verification | Implemented on unmerged `feat/autodev-v0.1` at reviewed commit `cc34e89`; not a default-branch or release claim |
+| Replay-only counterfactuals | Source and tests exist on a feature branch; no live integrated proof |
+| `unqualified -> shadow -> candidate -> canary -> active` lifecycle | Source and tests exist on a feature branch with degradation, quarantine, kill switch, and rollback; not yet a shipped claim |
+| End-to-end Trusted Change Report | Planned integration slice |
+| Per-task-category Route Lab recommendations | Planned integration slice |
+| Cockpit using production report contracts | Planned integration slice |
+
+The strategy audit distinguishes four evidence states: documented,
+source-implemented, live-configured, and behaviorally verified. A lower state
+never implies a higher one.
+
+## What this portfolio does not claim
+
+- It is not another generic model router, proxy, swarm framework, or shared
+  agent-memory product.
+- It does not claim that catalog rows or `auto/*` aliases prove live model
+  availability.
+- It does not claim provider/model counts that were not verified against the
+  current runtime.
+- It does not label fixture measurements as live benchmarks.
+- It does not claim SONA/RuVector learning loops are part of the flagship.
+- It does not claim packages are published until registries and clean installs
+  are independently verified.
+- It does not claim a worker, route recommendation, or counterfactual can
+  authorize its own promotion or release.
 
 ## Documentation
 
-- **Architecture**: [docs/architecture.md](verdict-core/docs/architecture.md)
-- **CLI Reference**: [docs/CLI_REFERENCE.md](verdict-core/docs/CLI_REFERENCE.md)
-- **API Reference**: [docs/API_REFERENCE.md](verdict-core/docs/API_REFERENCE.md)
-- **Configuration**: [docs/CONFIGURATION.md](verdict-core/docs/CONFIGURATION.md)
-- **Local Development**: [docs/guides/local-development.md](verdict-core/docs/guides/local-development.md)
-- **Production Deployment**: [docs/guides/production-deployment.md](verdict-core/docs/guides/production-deployment.md)
-- **Memory System**: [docs/guides/memory-system.md](verdict-core/docs/guides/memory-system.md)
+- [Portfolio product strategy](PORTFOLIO_PRODUCT_STRATEGY.md) — product boundary, capability audit, flagship flow, delivery plan, and release gate
+- [Core repository](https://github.com/mrnicholasbcarter-code/verdict-core) — implementation workstream; installation claims require current default-branch and clean-install verification
+- [Node repository](https://github.com/mrnicholasbcarter-code/verdict-node) — typed integration boundary
+- [Cockpit repository](https://github.com/mrnicholasbcarter-code/verdict-cockpit) — visual portfolio surface
 
----
+## Current status
 
-## License
+Active development. The near-term objective is one reproducible, honest
+vertical demo with an accepted change, a denied change, source-bound evidence,
+an advisory route recommendation, and a tested rollback path.
 
-MIT — see individual repos for details.
+## Release gate
 
----
+This portfolio is presentable only after a clean checkout reproduces the
+credential-free demo, accepted and denied changes, source-bound report,
+advisory route recommendation, rollback path, clean-install checks,
+contract-conformance checks, and independent reproduction of every primary
+claim from the tagged source.
 
-## Links
-
-- **Core**: https://github.com/mrnicholasbcarter-code/verdict-core
-- **Node**: https://github.com/mrnicholasbcarter-code/verdict-node
-- **Cockpit**: https://github.com/verdict/verdict-cockpit
-- **Risk**: https://github.com/verdict/verdict-risk
-- **Edge**: https://github.com/verdict/verdict-edge
-- **Backtest**: https://github.com/verdict/verdict-backtest
-- **OmniRoute**: https://github.com/verdict/omniroute
-- **RuVector**: https://github.com/ruvnet/ruvector
-- **Ruflo**: https://github.com/ruvnet/claude-flow
+MIT — see individual repositories for license details.


### PR DESCRIPTION
## Summary

Lands the portfolio product direction that supersedes the earlier router-first thesis.

Commits:
- `55b8bb9` docs(strategy): pause routing thesis for differentiation review
- `558f3ea` docs(strategy): define evidence-gated autodev portfolio

## Direction

Verdict becomes an **evidence-gated autonomous development control plane**, not a
router and not another agent framework. It decides whether an exact patch, produced
by an exact route from an exact source state, has earned the right to be accepted.

Boundary held by this direction:
- **OmniRoute** owns provider transport, discovery, combos, cost/latency/quota/health
  scoring, and fallback. A routing-first Verdict would be a weaker duplicate.
- **Ruflo** owns orchestration, swarms, workflows, and coordination ledgers.
- **Verdict** owns deterministic eligibility, protected-effect policy, source-state
  binding, independent acceptance evidence, and gated route-policy promotion.

Flagship slice: **AutoDev Route Lab**.

## Evidence

The uncommitted router-first strategy draft predates both commits here
(worktree mtime 2026-08-15 06:15 vs `55b8bb9` 08:31 and `558f3ea` 09:54), confirming
it is superseded rather than newer. That draft is preserved on
`preserve/eco-worktree-20260818` for history.

Docs-only change: no source, schema, or CI behavior is affected.