### PR TITLE
feat: rescue cross-repository compatibility gate and fix its CI (REL-001 foundation)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,12 +14,28 @@ jobs:
           path: verdict-ecosystem
       - uses: actions/checkout@v4
         with:
-          repository: verdict/verdict-core
+          repository: mrnicholasbcarter-code/verdict-core
           path: verdict-core
       - uses: actions/checkout@v4
         with:
-          repository: verdict/verdict-node
+          repository: mrnicholasbcarter-code/verdict-node
           path: verdict-node
+      - uses: actions/checkout@v4
+        with:
+          repository: mrnicholasbcarter-code/verdict-risk
+          path: verdict-risk
+      - uses: actions/checkout@v4
+        with:
+          repository: mrnicholasbcarter-code/verdict-strategy
+          path: verdict-strategy
+      - uses: actions/checkout@v4
+        with:
+          repository: mrnicholasbcarter-code/verdict-backtest
+          path: verdict-backtest
+      - uses: actions/checkout@v4
+        with:
+          repository: mrnicholasbcarter-code/verdict-cockpit
+          path: verdict-cockpit
       - name: Validate manifest
         working-directory: verdict-ecosystem
         run: python scripts/check_compatibility.py

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,25 @@
+name: Ecosystem Compatibility
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: verdict-ecosystem
+      - uses: actions/checkout@v4
+        with:
+          repository: verdict/verdict-core
+          path: verdict-core
+      - uses: actions/checkout@v4
+        with:
+          repository: verdict/verdict-node
+          path: verdict-node
+      - name: Validate manifest
+        working-directory: verdict-ecosystem
+        run: python scripts/check_compatibility.py

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,91 @@
+# Verdict Ecosystem Story Completion
+
+- **Date:** 2026-08-02
+- **Scope:** CON-001, NOD-002, CTX-002, PRO-001, SWARM-001
+- **Authority:** `verdict-core`; Node, Ruflo, memory, and domain repositories remain adapters/providers.
+- **Rule:** Reuse existing contracts and fail closed. No second policy authority.
+
+## Stories
+
+| ID | Story | Priority | Dependency | Status |
+| --- | --- | --- | --- | --- |
+| CON-001 | Cross-repository contract and release compatibility gate | P0 | Shared fixtures and package metadata | Planned |
+| NOD-002 | Enforce Core `ExecutionEnvelope` at the Node edge | P0 | Core envelope contract and TypeScript parity | Planned |
+| CTX-002 | Governed context and memory provider conformance | P1 | `MemoryGate`, `MemoryPlane`, context schemas | Planned |
+| PRO-001 | Standard provider receipts for risk, strategy, and backtest | P1 | Shared receipt contract | In progress |
+| SWARM-001 | Governed `SwarmSpec` and supervisor protocol | P1 | Envelope, evidence, and Ruflo lifecycle contracts | Planned |
+
+## Existing Foundations
+
+- Core: `verdict/contracts.py` already exposes `ExecutionEnvelope`, `TaskSpec`, `VerificationPlan`, and strict v1 parsing.
+- Core: `verdict/gateway_adapters.py` and `verdict/gateway_adapter_runtime.py` define versioned adapter manifests, requests, responses, route identity, capability negotiation, and failure normalization.
+- Core: `verdict/evidence_receipts.py` provides append-only, privacy-safe `EvidenceReceipt` and `EvidenceItem` contracts.
+- Core: `verdict/memory_adapters.py`, `verdict/memory_gate.py`, and `verdict/memory_plane.py` provide provider-neutral adapters, redaction, provenance, retention, supersession, tombstones, and explicit unavailable states.
+- Core: `verdict/ruflo_adapter.py`, `verdict/swarm_contracts.py`, `verdict/swarm_dispatcher.py`, and `verdict/lifecycle_controller.py` provide bounded orchestration, pause/resume/cancel, budgets, capability filtering, and verification hooks.
+- Node: `@bodanglin/verdict-contracts` is the canonical TypeScript dependency; `src/middleware/forwarder.ts` shares one pre-forward path for JSON and SSE.
+- Domain repositories: risk, strategy, and backtest expose deterministic APIs that must remain free of orchestration and network authority.
+
+## Execution Order
+
+1. Freeze Core Python/TypeScript/JSON fixtures for the shared envelope, context, receipt, and swarm contracts.
+2. Add Node envelope parsing and enforcement before upstream forwarding; use the same guard for streaming and non-streaming requests.
+3. Add Core context-provider conformance around the existing memory gate/plane and adapter registry.
+4. Add thin deterministic provider receipt adapters for risk, strategy, and backtest.
+5. Add validated `SwarmSpec` and supervisor evidence on top of existing Ruflo/swarm lifecycle primitives.
+6. Add the ecosystem compatibility manifest, deterministic checker, report artifact, and CI release gate.
+
+## Acceptance Gates
+
+### CON-001
+
+- Matrix covers Core, Node, risk, strategy/edge, backtest, cockpit, and ecosystem.
+- Schema/API fixture drift, incompatible major versions, missing repositories, and untrusted generated schemas fail with exact field/repository diagnostics.
+- Package/repository naming mismatches are explicit policy-controlled warnings or failures.
+- Dry-run release validation is offline and emits no credentials or PII.
+
+### NOD-002
+
+- Valid canonical envelopes round-trip Python to TypeScript.
+- Missing, expired, tampered, wrong-version, over-budget, disallowed-model, and disallowed-tool requests fail before forwarding.
+- Node never recalculates Core eligibility.
+- JSON and SSE use the same enforcement path.
+- Denials expose stable machine-readable codes.
+
+### CTX-002
+
+- Retrieval is advisory and cannot authorize execution.
+- Writes pass through `MemoryGate`; unverified or secret-bearing writes are rejected or quarantined.
+- Namespace, provenance, authority, retention, redaction, and rollback/supersession survive round trips.
+- Provider outages produce explicit `unknown`, `degraded`, or `unavailable` health states.
+
+### PRO-001
+
+- Risk, strategy, and backtest pass one shared request/result fixture.
+- Receipts contain run ID, provider identity/version, input/config hashes, outcome, provenance, and evidence references.
+- Replaying identical inputs is deterministic.
+- Providers cannot authorize execution.
+- Malformed, timed-out, or unavailable output becomes explicit degraded/unknown state.
+
+### SWARM-001
+
+- Invalid roles, duplicate IDs, missing verification, invalid budgets, and unbounded concurrency are rejected.
+- Every delegated slice has a bounded envelope and evidence reference.
+- Pause, resume, cancel, deterministic conflict resolution, and replay are tested.
+- Supervisor messages cannot mutate envelopes or escalate capabilities.
+
+## Verification Record
+
+Every story requires targeted tests plus repository-native checks. Minimum commands:
+
+```text
+Core: uv run pytest -q; ruff check; ruff format --check; mypy --strict; python -m build; git diff --check
+Node: npm run typecheck; npm run format:check; npm run build; npm test; npm run verify:package; npm run pack:dry-run
+Domain repos: pytest; ruff; mypy; package build; git diff --check
+Ecosystem: offline compatibility checker; fixture drift/missing-repository tests; workflow validation; git diff --check
+```
+
+Generated evidence belongs in ignored or explicit evidence directories. Existing uncommitted user work, story files, generated evidence, and worktree changes must not be reset, cleaned, or overwritten.
+
+## Current Implementation Note
+
+`verdict/provider_receipts.py` defines the first shared deterministic provider receipt primitive. It stores hashes instead of raw inputs, rejects sensitive metadata, validates schema/version, and remains informational rather than authoritative. Domain adapters and conformance tests must build on this primitive before the compatibility gate is finalized.

--- a/compatibility-manifest.json
+++ b/compatibility-manifest.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1",
+  "contract_version": "1",
+  "repositories": [
+    {"id": "verdict-core", "path": "../verdict-core", "package": "verdict-core", "contract_version": "1", "test_command": "uv run pytest -q", "status": "required"},
+    {"id": "verdict-node", "path": "../verdict-node", "package": "@bodanglin/verdict-node", "contract_version": "1", "test_command": "npm test", "status": "required"},
+    {"id": "verdict-risk", "path": "../verdict-risk", "package": "llm-gate-risk", "contract_version": "1", "test_command": "uv run pytest -q", "status": "required"},
+    {"id": "verdict-strategy", "path": "../verdict-strategy", "package": "verdict-edge", "contract_version": "1", "test_command": "uv run pytest -q", "status": "required"},
+    {"id": "verdict-backtest", "path": "../verdict-backtest", "package": "llm-gate-backtest", "contract_version": "1", "test_command": "uv run pytest -q", "status": "required"},
+    {"id": "verdict-cockpit", "path": "../verdict-cockpit", "package": "verdict-cockpit", "contract_version": "1", "test_command": "npm test", "status": "required"},
+    {"id": "verdict-ecosystem", "path": ".", "package": "verdict-ecosystem", "contract_version": "1", "test_command": "python scripts/check_compatibility.py", "status": "required"}
+  ]
+}

--- a/scripts/check_compatibility.py
+++ b/scripts/check_compatibility.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Offline cross-repository compatibility manifest checker."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = "1"
+REQUIRED_IDS = {
+    "verdict-core",
+    "verdict-node",
+    "verdict-risk",
+    "verdict-strategy",
+    "verdict-backtest",
+    "verdict-cockpit",
+    "verdict-ecosystem",
+}
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    manifest_path = root / "compatibility-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        errors, warnings, rows = validate_manifest(root, manifest)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "error", "errors": [str(exc)]}, indent=2))
+        return 2
+
+    report = {"status": "failed" if errors else "passed", "errors": errors, "warnings": warnings, "repositories": rows}
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if errors else 0
+
+
+def validate_manifest(root: Path, manifest: object) -> tuple[list[str], list[str], list[dict[str, object]]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    rows: list[dict[str, object]] = []
+    if not isinstance(manifest, dict):
+        return ["manifest must be an object"], warnings, rows
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        errors.append("manifest.schema_version must be '1'")
+    repositories = manifest.get("repositories")
+    if not isinstance(repositories, list):
+        return errors + ["manifest.repositories must be an array"], warnings, rows
+
+    seen: set[str] = set()
+    for index, item in enumerate(repositories):
+        prefix = f"repositories[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        required = {"id", "path", "package", "contract_version", "test_command", "status"}
+        missing = required - set(item)
+        if missing:
+            errors.append(f"{prefix} missing fields: {sorted(missing)}")
+            continue
+        repo_id = item["id"]
+        if not isinstance(repo_id, str) or not re.fullmatch(r"[a-z][a-z0-9-]+", repo_id):
+            errors.append(f"{prefix}.id must be a safe repository identifier")
+            continue
+        if repo_id in seen:
+            errors.append(f"duplicate repository id: {repo_id}")
+        seen.add(repo_id)
+        path_value = item["path"]
+        if not isinstance(path_value, str) or not path_value:
+            errors.append(f"{prefix}.path must be non-empty")
+            continue
+        path = (root / path_value).resolve()
+        exists = path.is_dir()
+        row: dict[str, object] = {"id": repo_id, "path": str(path), "exists": exists, "status": item["status"]}
+        rows.append(row)
+        if not exists:
+            errors.append(f"{repo_id}: repository path missing: {path}")
+        package = item["package"]
+        if not isinstance(package, str) or not package.strip():
+            errors.append(f"{repo_id}: package must be non-empty")
+        if item["contract_version"] != manifest.get("contract_version"):
+            errors.append(f"{repo_id}: contract_version differs from manifest")
+        if isinstance(package, str) and any(token in package.lower() for token in ("token=", "api_key", "password", "secret")):
+            errors.append(f"{repo_id}: secret-bearing package metadata rejected")
+        if repo_id == "verdict-strategy" and package != "verdict-edge":
+            warnings.append("verdict-strategy: repository/package naming differs (verdict-edge)")
+        if repo_id in {"verdict-risk", "verdict-backtest"} and not package.startswith("llm-gate-"):
+            warnings.append(f"{repo_id}: package naming differs from current manifest convention")
+
+    missing = REQUIRED_IDS - seen
+    errors.extend(f"missing repository: {repo_id}" for repo_id in sorted(missing))
+    return errors, warnings, rows
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Recovers the compatibility gate, which existed **only as an unpushed local commit**
and was at risk of being lost. None of these files were on any remote:

- `compatibility-manifest.json` — declares all 7 repositories, packages, contract
  version, and per-repo test command
- `scripts/check_compatibility.py` — fail-closed manifest validator
- `.github/workflows/compatibility.yml` — CI gate
- `IMPLEMENTATION_STATUS.md` — story completion tracker

## Commits

1. `cc3885b` — the rescued work, unchanged from the original local commit.
2. `f8bbbda` — fixes two defects that would have made the gate non-functional:
   - the workflow checked out `verdict/verdict-core` and `verdict/verdict-node`;
     that owner does not exist, so every run failed at checkout. Corrected to
     `mrnicholasbcarter-code`.
   - it checked out only 2 of the 7 repositories the manifest declares. Now checks
     out all six siblings, so the validator can actually see the full set.

All seven repositories are public, so the default `GITHUB_TOKEN` can read them.

## Verification

`python3 scripts/check_compatibility.py` passes locally against the full workspace:
7/7 repositories resolve, no errors, exit 0.

## Scope

This lands the REL-001 *foundation* only. The manifest still lacks repository and
registry URLs, import/CLI names, artifact versions, schema hashes, policy version,
runtime constraints, provider compatibility, maturity level, evidence timestamps,
release pins, and migration/rollback metadata. Those are tracked by #2 and follow
in a later PR. The validator also checks local directories rather than released
artifacts — also #2.