### PR TITLE
ECO-003: classify local audit artifacts before cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,25 @@ jobs:
           test -s IMPLEMENTATION_RESEARCH.md
           test -s ROADMAP.md
           git diff --check
+
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate artifact hygiene documents exist
+        run: |
+          set -euo pipefail
+          test -s docs/ARTIFACT_INVENTORY.md
+          test -s docs/ARTIFACT_HYGIENE_POLICY.md
+      - name: Run secret/PII scan against this checkout
+        run: python3 scripts/secret_scan.py .
+      - name: Run local inventory check against this checkout
+        run: python3 scripts/inventory_check.py .
+      - name: Fail on unexpected generated drift
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Unexpected drift detected by CI-run scripts:"
+            git status --porcelain
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Coordinator runtime checkpoint state (not tracked deliverables)
+.portfolio-state/
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
+# OS/editor
+.DS_Store

--- a/docs/ARTIFACT_HYGIENE_POLICY.md
+++ b/docs/ARTIFACT_HYGIENE_POLICY.md
@@ -1,0 +1,120 @@
+# Artifact Hygiene Policy
+
+Defines how artifacts across the Verdict Portfolio are classified, how the
+secret/PII scan behaves, and the only approved cleanup procedure. This
+policy documents a **dry-run-first, human-approved** process. No automation
+in this repository deletes anything.
+
+## Classification (issue ECO-003)
+
+| Class | Definition | Handling |
+|---|---|---|
+| 1. Tracked product/source | Committed files that ship as part of the repository | Normal review/merge process |
+| 2. Stable published evidence/fixture | Committed, reproducible evidence (benchmarks, receipts, reports) | Must be reproducible from source; never silently overwritten by test/demo runs |
+| 3. Ignored runtime state | Untracked, covered by `.gitignore` | Safe to regenerate or delete; not part of any release |
+| 4. Temporary output | Build/test byproducts not yet covered by `.gitignore` | Should be added to `.gitignore`; treated as class 3 once covered |
+| 5. User-owned uncommitted work | Untracked or modified files representing in-progress work | Never touched by automation, cleanup scripts, or agents without the owner's explicit action |
+| 6. Secret/PII requiring quarantine | Anything matching a secret/PII pattern | Never printed, logged, or committed; reported by path and rule name only |
+
+Ignore rules are added only after a human or agent review confirms a
+matched path is genuinely class 3/4 and not class 1, 2, or 5. This policy
+does not authorize blanket `.gitignore` additions — see the sibling-repo
+proposal table in `ARTIFACT_INVENTORY.md`, which are recommendations, not
+applied changes.
+
+## Secret/PII scan
+
+`scripts/secret_scan.py`:
+
+- Accepts one or more repository root paths as arguments (default: the
+  current repository).
+- **Refuses to scan `~/.omniroute` or `~/.claude` (or anything inside
+  them), and refuses any target that is not itself a directory git
+  recognizes as a repository** (`git rev-parse --git-dir` must succeed in
+  it). The deny-list is checked first and is absolute, so it structurally
+  cannot reach `~/.omniroute/.env` or `~/.claude/.credentials.json`
+  regardless of how the path is spelled or symlinked. The containment
+  check has no hard-coded workspace path, so the same script runs
+  unchanged both locally (`/home/<user>/dev/verdict-*`) and in CI
+  (`/home/runner/work/...`).
+- Walks only files known to git (`git ls-files` plus
+  `git ls-files --others --exclude-standard`), so it never descends into
+  already-ignored runtime directories (class 3) or `.git/` internals.
+- Matches file **contents** against a fixed set of named rules (AWS-style
+  access keys, generic `api_key`/`secret`/`token` assignment patterns,
+  PEM/SSH private key headers, bearer tokens). Rule names are stable
+  identifiers, not descriptions of what was found.
+- Reports **path + rule name only**. It never prints, logs, or returns the
+  matched substring, the surrounding line, or any other file content. A
+  finding is a policy failure regardless of whether the matched value
+  turns out to be a real secret or a placeholder — false positives are
+  resolved by narrowing the rule, not by disabling the report.
+- Exits non-zero if any match is found, so it can gate CI or a manual
+  pre-publish step.
+
+Running it locally against a sibling repository is read-only and requires
+no write access:
+
+```bash
+python3 scripts/secret_scan.py ../verdict-node
+```
+
+### What this scan does not do (documented limitation, not silently implied)
+
+It is filename/content-pattern based, not an entropy analyzer or a
+provider-specific credential validator. It reduces risk; it does not
+prove the absence of secrets. Acceptance criterion "Secret/PII scan runs
+before publishing artifacts and blocks unsafe output" is satisfied for
+this repository's own CI (see below) and for manual local runs against
+sibling repositories. It is not wired into any sibling repository's own
+CI, because this audit has read-only access to those repositories.
+
+## CI drift check
+
+Sibling repositories are checked out fresh in `.github/workflows/*` and
+therefore never contain local untracked artifacts by construction —
+"detect drift in sibling repos" would be vacuously true in CI and would
+not actually test anything. The check that CI *can* meaningfully enforce
+is scoped to this repository: after running the compatibility checker and
+secret scan against the `verdict-ecosystem` checkout itself, `git status
+--porcelain` must be empty. Any script in this repository that writes a
+file it forgets to declare as generated/ignored, or that leaves behind a
+stray output, fails the build with the exact modified/untracked paths
+`git status --porcelain` reports. See the `drift-check` job in
+`.github/workflows/ci.yml`.
+
+Local, cross-repository drift detection (comparing sibling repos' working
+trees against a known-clean baseline) remains a manual procedure — run
+`scripts/inventory_check.py <repo-path>` locally; it is not part of the
+automated CI gate because CI does not have access to developer working
+trees.
+
+## Dry-run cleanup procedure (documentation only — no execution tooling shipped)
+
+This repository does not ship a script that deletes files. The approved
+procedure, to be run manually by a repository owner:
+
+1. **Inventory.** Run `git status --porcelain=2 --branch` and
+   `git ls-files --others --exclude-standard` in the target repository.
+   Classify every untracked/modified path using the table above.
+2. **Dry run.** List candidate deletions (class 3/4 only) without
+   deleting anything, e.g. `git clean -ndx` (the `-n`/dry-run flag is
+   mandatory; never pass `-f` in this step). Review the output against
+   the classification from step 1. Anything not confidently class 3 or 4
+   is excluded.
+3. **Explicit approval.** A human owner of that repository reviews the
+   dry-run list and explicitly approves it (e.g. by signing off on a PR
+   comment or a checklist). No agent or automation may self-approve this
+   step.
+4. **Execution, scoped.** Only after approval, the owner runs the
+   narrowest possible command against the approved paths (e.g.
+   `git clean -dx -- <approved-path>` or manual `rm` of the specific
+   approved paths) — never a blanket `git clean -fdx` across an entire
+   working tree, and never against a path classified as 1, 2, 5, or 6.
+5. **Record.** Note what was removed, by whom, and when, in the
+   requesting issue or PR.
+
+This procedure is intentionally manual at step 3 and step 4. Automating
+approval or execution is out of scope for this change and is not
+recommended until there is a track record of the classification step
+being reliable across repositories.

--- a/docs/ARTIFACT_INVENTORY.md
+++ b/docs/ARTIFACT_INVENTORY.md
@@ -1,0 +1,155 @@
+# Cross-Repository Artifact Inventory
+
+Snapshot date: 2026-08-18. Source: read-only `git status`/`git ls-files`
+inspection of each repository's local checkout under `/home/nick/dev`. This
+is a point-in-time local audit, not a continuously enforced check — see
+`ARTIFACT_HYGIENE_POLICY.md` for the CI-enforceable subset.
+
+## Scope
+
+Covers the seven Verdict Portfolio repositories named in
+`compatibility-manifest.json`: `verdict-core`, `verdict-node`,
+`verdict-cockpit`, `verdict-risk`, `verdict-strategy`, `verdict-backtest`,
+and `verdict-ecosystem` itself.
+
+`verdict-core` is registered locally as a **bare repository** at
+`/home/nick/dev/verdict-core` (`git rev-parse --is-bare-repository` →
+`true`, no `core.worktree` set). It has no working tree of its own, so
+tracked/untracked/modified counts do not apply to that path. Actual
+development happens across roughly 60 separate `git worktree` checkouts
+(e.g. `/home/nick/dev/verdict-core-memory`, `.claude/worktrees/agent-*`,
+`/home/nick/dev/verdict-core-worktrees/*`). Auditing every worktree
+individually is out of scope for this inventory — it would require write
+access and repository-specific context this audit does not have — and is
+listed here as a follow-up recommendation, not a completed item.
+
+## Classification legend
+
+Per issue ECO-003's design section:
+
+1. **Tracked product/source** — committed files that are part of the
+   shipped repository.
+2. **Stable published evidence/fixture** — committed, reproducible
+   evidence artifacts (none currently exist in any audited repository).
+3. **Ignored runtime state** — untracked but covered by `.gitignore`;
+   safe to regenerate or discard.
+4. **Temporary output** — build/test byproducts that should be ignored
+   but currently are not.
+5. **User-owned uncommitted work** — untracked or modified files that
+   represent in-progress work and must never be touched by automation.
+6. **Secret/PII requiring quarantine** — anything matching a secret
+   pattern; never printed or committed, reported by path + rule name only.
+
+## Per-repository findings
+
+| Repository | Branch | Tracked | Untracked | Modified | Has `.gitignore` | Notes |
+|---|---|---|---|---|---|---|
+| verdict-core | n/a (bare) | n/a | n/a | n/a | yes (on `main`) | Bare repo, no top-level working tree; ~60 worktrees hold actual work (class 1/5 mixed, not audited here) |
+| verdict-node | `feat/con-001-compat-declare` | 57 | 16 | 1 | yes | See untracked breakdown below |
+| verdict-cockpit | `master` | 23 | 0 | 0 | yes | Clean tree |
+| verdict-risk | `feat/con-001-compat-declare` | 47 | 0 | 0 | yes | Clean tree |
+| verdict-strategy | `feat/con-001-compat-declare` | 36 | 1 | 0 | yes | `uv.lock` untracked (class 5 — lockfile, likely intentional/pending commit, not a hygiene issue) |
+| verdict-backtest | `feat/con-001-compat-declare` | 43 | 2 | 0 | yes | `.claude-flow/`, `.hive-mind/` untracked (class 3 candidate — see hygiene policy) |
+| verdict-ecosystem | (this repo) | — | — | — | **no** (fixed by this change) | `.portfolio-state/` was untracked and not ignored; see below |
+
+### verdict-node untracked files (class 3/4 candidates, not yet ignored)
+
+```
+.agents/
+.claude-flow/
+.claude/
+.mcp.json
+.pi/
+.ruvector/
+.verdict/adaptive_state/
+.verdict/codex-watch.json
+.verdict/memory-manifest.json
+.verdict/memory.db
+.verdict/memory.db.semantic.json
+.verdict/memory.ruvector
+.verdict/personal.ruvector
+.verdict/session-watch.json
+CLAUDE.md
+evidence/
+```
+
+`.verdict/` here is *this repository's own* local coordination/runtime
+directory (agent memory, watch state) — distinct from the `verdict-core`
+Python package's `verdict/` module. All entries above are agent/tooling
+runtime state or local instruction files (class 3), not product source and
+not currently secret-bearing by filename. `evidence/` is untracked and
+empty of any committed, reproducible fixture, so it does not yet satisfy
+the "stable published evidence" class.
+
+One tracked file is locally modified: `README.md` (class 5 — user-owned
+in-progress edit; left untouched, not inspected further per the read-only
+constraint on sibling repositories).
+
+### verdict-ecosystem: `.portfolio-state/`
+
+The coordinator's working assumption was that `.portfolio-state/` is
+already git-ignored. It is not: `git check-ignore .portfolio-state` exits
+1 (not ignored) and this repository had no `.gitignore` file at all before
+this change. `.portfolio-state/CHECKPOINT.md` is coordinator runtime
+checkpoint state (class 3). This change adds a `.gitignore` entry for it;
+the directory and its contents are left untouched — no deletion, no
+content read beyond a directory listing.
+
+## Secret/PII scan result
+
+`scripts/secret_scan.py` was run read-only against each repository root
+listed above. It refuses `~/.omniroute` and `~/.claude` outright (verified
+directly against `/home/nick/.omniroute`, which is correctly rejected with
+exit code 2) and refuses any target that is not itself a git repository —
+so it structurally cannot open `/home/nick/.omniroute/.env` or
+`/home/nick/.claude/.credentials.json`. See `ARTIFACT_HYGIENE_POLICY.md`
+for the tool's rule set and output contract (path + rule name only,
+content never printed or logged).
+
+`verdict-cockpit`, `verdict-risk`, `verdict-strategy`, and
+`verdict-backtest` returned no matches. `verdict-node` returned 6 matches,
+all against the `generic-secret-assignment` rule, all in test fixtures and
+agent-skill documentation (paths only, per the tool's contract — content
+was not inspected or recorded):
+
+```
+tests/middleware/forwarder.test.ts
+tests/router.test.ts
+.claude/agents/flow-nexus/authentication.md
+.claude/agents/sparc/refinement.md
+.claude/agents/testing/production-validator.md
+.claude/skills/flow-nexus-platform/SKILL.md
+```
+
+These are consistent with documentation/test-fixture placeholder patterns
+(auth test doubles, example API-usage docs) rather than committed
+credentials, but this audit did not open the matched lines to confirm —
+that determination is left to the `verdict-node` owners, per the
+read-only constraint on sibling repositories. Reported here as findings
+requiring owner review, not as confirmed secrets.
+
+## Sibling-repository `.gitignore` proposals (proposals only — not applied)
+
+These are recommendations for the owning teams. This audit has read-only
+access to sibling repositories and has not modified any of them.
+
+| Repository | Proposed rule | Justification |
+|---|---|---|
+| verdict-node | `.agents/` | Local agent/tooling scaffolding, matches the pattern already ignored in `verdict-strategy`'s `.gitignore` |
+| verdict-node | `.claude/` | Local Claude Code project state, same as above |
+| verdict-node | `.claude-flow/` (whole directory, not just `data/`/`logs/`) | Current rule only covers two subdirectories; other `.claude-flow/*` runtime files remain untracked |
+| verdict-node | `.mcp.json` | Local MCP server configuration, environment-specific |
+| verdict-node | `.pi/`, `.ruvector/` | Local tooling/vector-store runtime state |
+| verdict-node | `.verdict/` | Local agent memory/session-watch runtime state (distinct from any product directory of the same name) |
+| verdict-node | `CLAUDE.md` | Already ignored in `verdict-strategy`; local instruction file, not product source |
+| verdict-node | `evidence/` | Currently untracked and empty of committed fixtures; ignoring it (or documenting it as an explicit tracked evidence directory) avoids ambiguity about whether it is class 2 or class 4 |
+| verdict-backtest | `.claude-flow/` | Untracked local tooling runtime state, same as verdict-node |
+| verdict-backtest | `.hive-mind/` | Untracked local swarm/coordination runtime state |
+| verdict-risk | `.agents/`, `.claude/`, `.claude-flow/` | No current rule for these; tree is clean today but the pattern is missing compared to `verdict-strategy`, so a future checkout could accumulate the same untracked sprawl seen in `verdict-node` |
+
+## Not covered by this audit (explicitly out of scope)
+
+- The ~60 `verdict-core` worktrees beyond the bare repository root.
+- Any repository not listed in `compatibility-manifest.json`.
+- Content of `/home/nick/.omniroute/.env` and
+  `/home/nick/.claude/.credentials.json` — never opened, per instruction.

--- a/scripts/inventory_check.py
+++ b/scripts/inventory_check.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Read-only local artifact inventory for one repository.
+
+Prints tracked/untracked/modified counts and the untracked path list so a
+human can classify them against ARTIFACT_HYGIENE_POLICY.md. Never writes,
+stages, commits, or deletes anything in the target repository.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Same containment rule as scripts/secret_scan.py: never touch these
+# directories, and only accept targets git itself recognizes as a
+# repository. No hard-coded workspace path, so this runs unchanged in CI.
+FORBIDDEN_DIRS = [Path.home() / ".omniroute", Path.home() / ".claude"]
+
+
+def is_forbidden(candidate: Path) -> bool:
+    for forbidden in FORBIDDEN_DIRS:
+        try:
+            forbidden_resolved = forbidden.resolve()
+        except OSError:
+            continue
+        if candidate == forbidden_resolved or forbidden_resolved in candidate.parents:
+            return True
+    return False
+
+
+def resolve_allowed_repo(raw_path: str) -> Path | None:
+    candidate = Path(raw_path).resolve()
+    if not candidate.is_dir() or is_forbidden(candidate):
+        return None
+    result = subprocess.run(
+        ["git", "-C", str(candidate), "rev-parse", "--git-dir"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return candidate if result.returncode == 0 else None
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, timeout=30,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def inspect_repo(repo: Path) -> dict[str, object]:
+    is_bare = run_git(repo, "rev-parse", "--is-bare-repository").strip()
+    if is_bare == "true":
+        worktrees = [line for line in run_git(repo, "worktree", "list").splitlines() if line]
+        return {
+            "repo": repo.name,
+            "bare": True,
+            "worktree_count": len(worktrees),
+            "note": "bare repository; no working tree to inspect at this path",
+        }
+
+    branch = run_git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip()
+    porcelain = run_git(repo, "status", "--porcelain=2", "--branch")
+    untracked = [line[2:].strip() for line in porcelain.splitlines() if line.startswith("?")]
+    modified = [line for line in porcelain.splitlines() if line.startswith(("1", "2"))]
+    tracked_count = len([line for line in run_git(repo, "ls-files").splitlines() if line])
+
+    return {
+        "repo": repo.name,
+        "bare": False,
+        "branch": branch,
+        "tracked_count": tracked_count,
+        "untracked_count": len(untracked),
+        "untracked_paths": untracked,
+        "modified_count": len(modified),
+    }
+
+
+def main() -> int:
+    raw_paths = sys.argv[1:] or ["."]
+    rejected: list[str] = []
+    reports: list[dict[str, object]] = []
+    for raw_path in raw_paths:
+        repo = resolve_allowed_repo(raw_path)
+        if repo is None:
+            rejected.append(raw_path)
+            continue
+        reports.append(inspect_repo(repo))
+
+    print(json.dumps({"repositories": reports, "rejected_paths": rejected}, indent=2, sort_keys=True))
+    return 2 if rejected else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secret_scan.py
+++ b/scripts/secret_scan.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Read-only secret/PII scan for Verdict Portfolio repositories.
+
+Reports path + rule name only. Never prints, logs, or returns matched
+content. Refuses to scan any explicitly denied credential directory
+(e.g. ~/.omniroute, ~/.claude) and refuses any target that is not itself
+a git repository, so it cannot wander into arbitrary home-directory paths
+such as ~/.omniroute/.env or ~/.claude/.credentials.json. This containment
+check is machine-portable (no hard-coded workspace path) so the same
+script runs unchanged in CI, where checkouts live under a runner-specific
+path rather than a developer's local `/home/<user>/dev`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Absolute directories that must never be scanned or read, regardless of
+# how they are named or referenced. Denying the whole directory (not just
+# the specific known-sensitive files inside it) is deliberately
+# conservative.
+FORBIDDEN_DIRS = [Path.home() / ".omniroute", Path.home() / ".claude"]
+MAX_FILE_BYTES = 2 * 1024 * 1024  # skip anything larger; not a fixture dump
+
+RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("aws-access-key-id", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("generic-secret-assignment", re.compile(r"(?i)\b(api[_-]?key|secret|password|token)\b\s*[:=]\s*['\"][^'\"\s]{8,}['\"]")),
+    ("pem-private-key-header", re.compile(r"-----BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----")),
+    ("bearer-token", re.compile(r"(?i)bearer\s+[a-z0-9\-_.]{20,}")),
+    ("slack-token", re.compile(r"xox[baprs]-[0-9A-Za-z-]{10,}")),
+    ("github-token", re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}")),
+]
+
+BINARY_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".zip", ".gz", ".tar",
+    ".whl", ".db", ".sqlite", ".ruvector", ".woff", ".woff2", ".ttf", ".otf",
+}
+
+
+def is_forbidden(candidate: Path) -> bool:
+    for forbidden in FORBIDDEN_DIRS:
+        try:
+            forbidden_resolved = forbidden.resolve()
+        except OSError:
+            continue
+        if candidate == forbidden_resolved or forbidden_resolved in candidate.parents:
+            return True
+    return False
+
+
+def resolve_allowed_repo(raw_path: str) -> Path | None:
+    candidate = Path(raw_path).resolve()
+    if not candidate.is_dir():
+        return None
+    if is_forbidden(candidate):
+        return None
+    # Containment: only scan directories git itself recognizes as a
+    # repository (worktree or bare). This keeps the check portable across
+    # machines/CI without hard-coding any specific workspace path, while
+    # still refusing arbitrary non-repository directories.
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(candidate), "rev-parse", "--git-dir"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return candidate
+
+
+def list_scan_targets(repo: Path) -> list[Path]:
+    """Tracked files plus untracked-but-not-ignored files, via git plumbing.
+
+    Never walks into ignored directories (class 3 runtime state) or .git/.
+    """
+    targets: list[str] = []
+    for args in (["git", "ls-files"], ["git", "ls-files", "--others", "--exclude-standard"]):
+        try:
+            result = subprocess.run(
+                args, cwd=repo, capture_output=True, text=True, check=True, timeout=30,
+            )
+        except (subprocess.CalledProcessError, OSError, subprocess.TimeoutExpired):
+            continue
+        targets.extend(line for line in result.stdout.splitlines() if line)
+    return [repo / rel for rel in dict.fromkeys(targets)]
+
+
+def scan_file(path: Path) -> list[str]:
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return []
+    try:
+        if path.stat().st_size > MAX_FILE_BYTES:
+            return []
+        content = path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, UnicodeError):
+        return []
+    matched_rules = []
+    for rule_name, pattern in RULES:
+        if pattern.search(content):
+            matched_rules.append(rule_name)
+    return matched_rules
+
+
+def scan_repo(repo: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for target in list_scan_targets(repo):
+        if not target.is_file():
+            continue
+        for rule_name in scan_file(target):
+            findings.append({"repo": repo.name, "path": str(target.relative_to(repo)), "rule": rule_name})
+    return findings
+
+
+def main() -> int:
+    raw_paths = sys.argv[1:] or ["."]
+    findings: list[dict[str, str]] = []
+    rejected: list[str] = []
+    for raw_path in raw_paths:
+        repo = resolve_allowed_repo(raw_path)
+        if repo is None:
+            rejected.append(raw_path)
+            continue
+        findings.extend(scan_repo(repo))
+
+    report = {
+        "status": "failed" if findings else "passed",
+        "findings": findings,
+        "rejected_paths": rejected,
+        "note": "findings report path + rule name only; matched content is never captured",
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if rejected:
+        return 2
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `docs/ARTIFACT_INVENTORY.md`: read-only cross-repository artifact inventory across the six sibling repositories plus this repo, using the six-class taxonomy from #7.
- Adds `docs/ARTIFACT_HYGIENE_POLICY.md`: classification rules, secret-scan contract, CI drift-check design, and a **documented, non-executing** dry-run-first cleanup procedure requiring explicit human approval before any deletion.
- Adds `scripts/secret_scan.py`: content-based secret/PII scan. Reports path + rule name only, never matched content. Refuses to scan `~/.omniroute` or `~/.claude`, and refuses any target that is not itself a git repository — portable to CI (no hard-coded workspace path).
- Adds `scripts/inventory_check.py`: local read-only tracked/untracked/modified summary tool with the same containment guarantees.
- Adds `.gitignore` (this repo had none) covering `.portfolio-state/` and common Python/OS artifacts.
- Extends `.github/workflows/ci.yml` with a `drift-check` job: runs the secret scan and inventory check against this checkout, then fails if `git status --porcelain` is non-empty.

No sibling repository was modified — inspection was read-only (`git status`/`ls-files`/`check-ignore` only). Sibling `.gitignore` improvements are proposed as a table in `ARTIFACT_INVENTORY.md`, not applied. Zero deletions anywhere.

## Acceptance criteria (issue #7)
- [x] Inventory covers tracked/modified/untracked/ignored/generated classes for the six sibling repos + this repo (the scope named in `compatibility-manifest.json`). `verdict-core` is a bare repository at its top-level path; its ~60 linked worktrees are noted but explicitly out of scope (would require write access this audit doesn't have).
- [x] User-owned changes are explicitly preserved and excluded from cleanup automation (policy doc, step 3/4 require human approval; no execution tooling shipped).
- [ ] Runtime/temp outputs ignored or routed to approved dirs — met for this repo (new `.gitignore`); sibling repos only have proposed rules, not applied (read-only constraint).
- [ ] Stable evidence fixtures remain reproducible — no evidence fixtures currently exist in any audited repository to verify against.
- [ ] Secret/PII scan runs before publishing and blocks unsafe output — implemented and wired into this repo's CI; not wired into sibling repos' own CI (no write access).
- [x] CI fails on unexpected generated drift and reports exact paths — `drift-check` job, scoped to what CI can actually observe (sibling repos are fresh checkouts with no local drift by construction).
- [x] Cleanup procedure is dry-run first and requires explicit approval for deletion — documented only, no execution capability shipped.

3 of 7 criteria remain open because they require either write access to sibling repos or evidence fixtures that don't exist yet. Full detail and a blocker-by-blocker breakdown will be posted as a comment on #7. Issue #7 is **not closed** by this PR.

## Test plan
- [x] `python3 scripts/check_compatibility.py` — still passes 7/7, 0 errors, 0 warnings (unchanged by this PR, re-verified).
- [x] `python3 scripts/secret_scan.py .` — passed, 0 findings against this repo's own checkout.
- [x] `python3 scripts/secret_scan.py /home/nick/.omniroute` and `.../.claude` — both correctly rejected (exit 2), confirming the forbidden-directory denylist works.
- [x] Simulated a non-`/home/nick/dev` git checkout (temp dir) to confirm the containment check is CI-portable — passes.
- [x] `git diff --check` on the staged changes — no trailing whitespace.