### PR TITLE
ECO-003: verifiable evidence fixtures and a tested secret-scan gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
           set -euo pipefail
           test -s docs/ARTIFACT_INVENTORY.md
           test -s docs/ARTIFACT_HYGIENE_POLICY.md
+      # Publish gate: the scan runs before any evidence is treated as
+      # publishable, and a non-zero exit stops the job here.
       - name: Run secret/PII scan against this checkout
         run: python3 scripts/secret_scan.py .
+      - name: Verify stable evidence fixtures are reproducible
+        run: python3 scripts/build_evidence.py
       - name: Run local inventory check against this checkout
         run: python3 scripts/inventory_check.py .
       - name: Fail on unexpected generated drift

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -39,3 +39,9 @@ jobs:
       - name: Validate manifest
         working-directory: verdict-ecosystem
         run: python scripts/check_compatibility.py
+      # Run here rather than in ci.yml: tests/test_check_compatibility.py
+      # resolves the manifest's `../verdict-*` paths, so it needs the
+      # sibling checkouts this job already provides.
+      - name: Run unit tests
+        working-directory: verdict-ecosystem
+        run: python -m unittest discover -s tests -v

--- a/docs/ARTIFACT_HYGIENE_POLICY.md
+++ b/docs/ARTIFACT_HYGIENE_POLICY.md
@@ -69,6 +69,55 @@ this repository's own CI (see below) and for manual local runs against
 sibling repositories. It is not wired into any sibling repository's own
 CI, because this audit has read-only access to those repositories.
 
+### Blocking behaviour is tested, not assumed
+
+`tests/test_secret_scan.py` proves the gate blocks rather than merely
+reports: one synthetic fixture per rule asserts a non-zero exit, a clean
+fixture asserts exit 0, and an unscannable target asserts exit 2 — an
+unreachable path must never be reported as a clean pass. The tests also
+assert the negative-disclosure guarantee, checking that the matched
+string never appears anywhere in the emitted report.
+
+Unsafe fixtures are synthesized into throwaway git repositories under the
+OS temp directory at run time. No secret-shaped string is committed to
+this repository, which would otherwise make `drift-check` fail on its own
+test suite; for the same reason the sample values in that module are
+assembled by concatenation, so no single line matches a scanner rule.
+
+## Stable published evidence fixtures (class 2)
+
+Class-2 artifacts live in `evidence/` and are the only committed files in
+this repository that are *generated*. Two properties are enforced, not
+merely asserted:
+
+**Reproducible.** Every fixture is a pure function of committed source —
+today, `compatibility-manifest.json` alone. The generator
+(`scripts/build_evidence.py`) reads no clock, no environment, no absolute
+path, and never probes the filesystem for sibling repositories. Machine-
+local fields such as `path` are projected out, precisely because a fixture
+containing one developer's `/home/<user>/dev/...` could not be regenerated
+byte-identically anywhere else. `evidence/EVIDENCE_MANIFEST.json` records
+the SHA-256 of each fixture *and* of the source it was derived from, so
+provenance is checkable without trusting the commit that introduced it.
+
+**Not overwritten by tests or demos.** The generator writes only under an
+explicit `--write` flag; its default mode is a read-only `--check` that
+regenerates in memory and diffs. Any caller that runs it without
+arguments — CI, a test, a demo, an agent — is structurally unable to
+mutate `evidence/`. `tests/test_evidence_fixture.py` asserts this
+directly: it snapshots the digests of `evidence/`, runs the fixture test
+suite, and fails if any digest moved.
+
+To change a fixture you must change its source and regenerate:
+
+```bash
+python3 scripts/build_evidence.py --write
+```
+
+A stale or hand-edited fixture fails CI with the exact path and both
+digests. Hand-editing a file under `evidence/` is never correct — the
+regeneration check will revert the meaning of the edit at the next build.
+
 ## CI drift check
 
 Sibling repositories are checked out fresh in `.github/workflows/*` and

--- a/evidence/EVIDENCE_MANIFEST.json
+++ b/evidence/EVIDENCE_MANIFEST.json
@@ -1,0 +1,15 @@
+{
+  "artifacts": [
+    {
+      "path": "evidence/compatibility-baseline.json",
+      "sha256": "502244e922a719f199c23545fa73ae497abae96e14050dd36667b390188eb8a6"
+    }
+  ],
+  "class": "2-stable-published-evidence",
+  "generator": "scripts/build_evidence.py",
+  "policy": "docs/ARTIFACT_HYGIENE_POLICY.md",
+  "source": {
+    "path": "compatibility-manifest.json",
+    "sha256": "f73642a54733d00ba27a4521af0f065ca7a647b68f2c40c1614fe8287be2b4f6"
+  }
+}

--- a/evidence/compatibility-baseline.json
+++ b/evidence/compatibility-baseline.json
@@ -1,0 +1,107 @@
+{
+  "contract_version": "1",
+  "evidence_timestamp": "2026-08-18T00:00:00Z",
+  "policy_version": "1",
+  "release_train": {
+    "deferred_checks": [
+      {
+        "blocked_by": "https://github.com/mrnicholasbcarter-code/verdict-core/issues/220",
+        "name": "schema-hashes"
+      },
+      {
+        "blocked_by": "https://github.com/mrnicholasbcarter-code/verdict-node/issues/31",
+        "name": "cross-repository-contract-smoke-tests"
+      }
+    ],
+    "id": "rel-001-partial-2026-08-18",
+    "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md",
+    "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md"
+  },
+  "repositories": [
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-backtest",
+      "maturity": "alpha",
+      "package": "llm-gate-backtest",
+      "policy_version": "1",
+      "publication_status": "source-only",
+      "release_train_pin": "3c89fb8d4dca086a4ac05e476177243148279a91",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-cockpit",
+      "maturity": "alpha",
+      "package": "verdict-cockpit",
+      "policy_version": "1",
+      "publication_status": "private-application",
+      "release_train_pin": "4dbdf403adfbd68f97ed61a10aae64835c0a2e21",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-core",
+      "maturity": "alpha",
+      "package": "verdict-core",
+      "policy_version": "1",
+      "publication_status": "source-only",
+      "release_train_pin": "bc93e455ed4dd7f2c369ff66132b152cfa0da04f",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "unreleased",
+      "contract_version": "1",
+      "id": "verdict-ecosystem",
+      "maturity": "alpha",
+      "package": "verdict-ecosystem",
+      "policy_version": "1",
+      "publication_status": "documentation-only",
+      "release_train_pin": "e0743cea8c9f63a0cd4bbf0d2177ff4c442e03cb",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-node",
+      "maturity": "alpha",
+      "package": "@bodanglin/verdict-node",
+      "policy_version": "1",
+      "publication_status": "published",
+      "release_train_pin": "48f8189c0e69bd915f1a1dfd7beec7e5e3e05e62",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-risk",
+      "maturity": "alpha",
+      "package": "llm-gate-risk",
+      "policy_version": "1",
+      "publication_status": "source-only",
+      "release_train_pin": "65477ec4a487d5893c988802e559a823202018e7",
+      "status": "required",
+      "support_level": "experimental"
+    },
+    {
+      "artifact_version": "0.1.0",
+      "contract_version": "1",
+      "id": "verdict-strategy",
+      "maturity": "alpha",
+      "package": "verdict-edge",
+      "policy_version": "1",
+      "publication_status": "source-only",
+      "release_train_pin": "d393ca0a829658e5b7078ed34dddde2aa9830114",
+      "status": "required",
+      "support_level": "experimental"
+    }
+  ],
+  "schema_version": "2"
+}

--- a/scripts/build_evidence.py
+++ b/scripts/build_evidence.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Build and verify the stable published evidence fixtures (ECO-003 class 2).
+
+Class-2 artifacts are *published evidence*: committed, reproducible, and
+never silently overwritten by a test or demo run. This script is the only
+supported writer for `evidence/`, and it writes only when explicitly asked
+with `--write`. The default mode is `--check`, which regenerates the
+fixture in memory and compares it against what is committed, so any caller
+that runs the script without arguments — CI, a test, a demo — is
+structurally incapable of mutating the fixture.
+
+Reproducibility rests on the fixture being a pure function of committed
+source: it is derived from `compatibility-manifest.json` only. No
+timestamps, no absolute paths, no filesystem probing, no environment. The
+same commit therefore always produces byte-identical evidence on any
+machine, which is what makes the recorded SHA-256 digests meaningful as
+provenance rather than as a snapshot of one developer's laptop.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "compatibility-manifest.json"
+EVIDENCE_DIR = ROOT / "evidence"
+BASELINE = EVIDENCE_DIR / "compatibility-baseline.json"
+MANIFEST = EVIDENCE_DIR / "EVIDENCE_MANIFEST.json"
+
+# Fields projected into the baseline. Deliberately excludes `path` (a
+# machine-local relative path) and anything else that could differ between
+# a developer checkout and a CI runner.
+BASELINE_FIELDS = (
+    "id",
+    "package",
+    "artifact_version",
+    "contract_version",
+    "policy_version",
+    "publication_status",
+    "release_train_pin",
+    "maturity",
+    "support_level",
+    "status",
+)
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def serialize(payload: object) -> str:
+    """Canonical JSON: sorted keys, fixed indent, trailing newline."""
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def build_baseline(manifest: dict) -> dict:
+    repositories = []
+    for repo in manifest.get("repositories", []):
+        repositories.append({field: repo.get(field) for field in BASELINE_FIELDS})
+    repositories.sort(key=lambda row: row["id"] or "")
+    return {
+        "contract_version": manifest.get("contract_version"),
+        "policy_version": manifest.get("policy_version"),
+        "schema_version": manifest.get("schema_version"),
+        "release_train": manifest.get("release_train"),
+        "evidence_timestamp": manifest.get("evidence_timestamp"),
+        "repositories": repositories,
+    }
+
+
+def build_manifest(source_text: str, baseline_text: str) -> dict:
+    return {
+        "generator": "scripts/build_evidence.py",
+        "policy": "docs/ARTIFACT_HYGIENE_POLICY.md",
+        "class": "2-stable-published-evidence",
+        "source": {
+            "path": "compatibility-manifest.json",
+            "sha256": sha256_text(source_text),
+        },
+        "artifacts": [
+            {
+                "path": "evidence/compatibility-baseline.json",
+                "sha256": sha256_text(baseline_text),
+            }
+        ],
+    }
+
+
+def render() -> dict[Path, str]:
+    """Return the full evidence set as {path: canonical text}."""
+    source_text = SOURCE.read_text(encoding="utf-8")
+    baseline_text = serialize(build_baseline(json.loads(source_text)))
+    manifest_text = serialize(build_manifest(source_text, baseline_text))
+    return {BASELINE: baseline_text, MANIFEST: manifest_text}
+
+
+def check() -> tuple[int, list[str]]:
+    problems: list[str] = []
+    for path, expected in render().items():
+        rel = path.relative_to(ROOT)
+        if not path.exists():
+            problems.append(f"{rel}: missing; run scripts/build_evidence.py --write")
+            continue
+        actual = path.read_text(encoding="utf-8")
+        if actual != expected:
+            problems.append(
+                f"{rel}: stale or hand-edited "
+                f"(committed sha256 {sha256_text(actual)[:12]}, "
+                f"expected {sha256_text(expected)[:12]}); "
+                "regenerate with scripts/build_evidence.py --write"
+            )
+    return (1 if problems else 0), problems
+
+
+def write() -> list[str]:
+    EVIDENCE_DIR.mkdir(exist_ok=True)
+    changed: list[str] = []
+    for path, text in render().items():
+        previous = path.read_text(encoding="utf-8") if path.exists() else None
+        if previous != text:
+            path.write_text(text, encoding="utf-8")
+            changed.append(str(path.relative_to(ROOT)))
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="regenerate the evidence fixtures (the only mode that writes)",
+    )
+    args = parser.parse_args()
+
+    if args.write:
+        changed = write()
+        print(json.dumps({"mode": "write", "changed": changed}, indent=2, sort_keys=True))
+        return 0
+
+    code, problems = check()
+    print(
+        json.dumps(
+            {
+                "mode": "check",
+                "status": "failed" if problems else "passed",
+                "problems": problems,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evidence_fixture.py
+++ b/tests/test_evidence_fixture.py
@@ -1,0 +1,120 @@
+"""Class-2 evidence fixtures must be reproducible and test-run-immutable.
+
+Covers the ECO-003 acceptance criterion "stable evidence fixtures remain
+reproducible and are not overwritten by tests/demos". The two halves are
+tested separately: reproducibility (regenerating from committed source
+yields byte-identical output, and the recorded digests match) and
+immutability (nothing short of an explicit `--write` mutates `evidence/`,
+including this very test module).
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "build_evidence", ROOT / "scripts" / "build_evidence.py"
+)
+assert SPEC and SPEC.loader
+EVIDENCE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = EVIDENCE
+SPEC.loader.exec_module(EVIDENCE)
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def snapshot() -> dict[str, str]:
+    return {p.name: digest(p) for p in sorted(EVIDENCE.EVIDENCE_DIR.iterdir()) if p.is_file()}
+
+
+class EvidenceReproducibilityTests(unittest.TestCase):
+    def test_committed_fixtures_match_regeneration(self) -> None:
+        code, problems = EVIDENCE.check()
+        self.assertEqual(problems, [])
+        self.assertEqual(code, 0)
+
+    def test_regeneration_is_deterministic(self) -> None:
+        first = EVIDENCE.render()
+        second = EVIDENCE.render()
+        self.assertEqual(
+            {str(k): v for k, v in first.items()},
+            {str(k): v for k, v in second.items()},
+        )
+
+    def test_recorded_digests_match_artifacts(self) -> None:
+        manifest = json.loads(EVIDENCE.MANIFEST.read_text(encoding="utf-8"))
+        for artifact in manifest["artifacts"]:
+            with self.subTest(artifact=artifact["path"]):
+                self.assertEqual(digest(ROOT / artifact["path"]), artifact["sha256"])
+        source = manifest["source"]
+        self.assertEqual(digest(ROOT / source["path"]), source["sha256"])
+
+    def test_baseline_excludes_machine_local_fields(self) -> None:
+        """A fixture carrying local paths would not be reproducible elsewhere."""
+        baseline = json.loads(EVIDENCE.BASELINE.read_text(encoding="utf-8"))
+        for repo in baseline["repositories"]:
+            with self.subTest(repo=repo["id"]):
+                self.assertNotIn("path", repo)
+
+    def test_baseline_covers_every_manifest_repository(self) -> None:
+        manifest = json.loads(EVIDENCE.SOURCE.read_text(encoding="utf-8"))
+        baseline = json.loads(EVIDENCE.BASELINE.read_text(encoding="utf-8"))
+        self.assertEqual(
+            sorted(repo["id"] for repo in manifest["repositories"]),
+            sorted(repo["id"] for repo in baseline["repositories"]),
+        )
+
+    def test_stale_fixture_is_reported_with_exact_path(self) -> None:
+        """A drifted fixture must fail loudly and name the file."""
+        original = EVIDENCE.BASELINE.read_text(encoding="utf-8")
+        try:
+            EVIDENCE.BASELINE.write_text(original + "\n", encoding="utf-8")
+            code, problems = EVIDENCE.check()
+            self.assertEqual(code, 1)
+            self.assertTrue(
+                any("evidence/compatibility-baseline.json" in problem for problem in problems),
+                problems,
+            )
+        finally:
+            EVIDENCE.BASELINE.write_text(original, encoding="utf-8")
+
+
+class EvidenceImmutabilityTests(unittest.TestCase):
+    def test_default_invocation_does_not_write(self) -> None:
+        before = snapshot()
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "build_evidence.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(snapshot(), before)
+
+    def test_check_helper_does_not_write(self) -> None:
+        before = snapshot()
+        EVIDENCE.check()
+        self.assertEqual(snapshot(), before)
+
+    def test_this_test_run_leaves_evidence_untouched(self) -> None:
+        """Guards the criterion directly: tests/demos must not overwrite class-2 output."""
+        before = snapshot()
+        with open(os.devnull, "w", encoding="utf-8") as sink:
+            unittest.TextTestRunner(stream=sink, verbosity=0).run(
+                unittest.TestLoader().loadTestsFromTestCase(EvidenceReproducibilityTests)
+            )
+        self.assertEqual(snapshot(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -1,0 +1,160 @@
+"""The secret/PII scan must actually block unsafe output, not just report.
+
+Covers the ECO-003 acceptance criterion "secret/PII scan runs before
+publishing artifacts and blocks unsafe output". Blocking is what is under
+test here: a non-zero exit is the gate, so every unsafe fixture asserts on
+the exit code, not merely on the presence of a finding.
+
+Every unsafe fixture is synthesized at run time into a throwaway git
+repository under the OS temp directory. Nothing containing a
+secret-shaped string is ever committed to this repository — which would
+otherwise make this repo's own `drift-check` gate fail on its own test
+suite. For the same reason the sample values below are assembled by
+concatenation rather than written as literals: a literal would be matched
+by the scanner while it walks `tests/`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCANNER_PATH = ROOT / "scripts" / "secret_scan.py"
+SPEC = importlib.util.spec_from_file_location("secret_scan", SCANNER_PATH)
+assert SPEC and SPEC.loader
+SCANNER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SCANNER
+SPEC.loader.exec_module(SCANNER)
+
+# Assembled at import time so no secret-shaped literal exists on any single
+# line of this file. Values are syntactically valid but deliberately fake.
+UNSAFE_SAMPLES = {
+    "aws-access-key-id": "static_id = '" + "AKIA" + "IOSFODNN7EXAMPLE" + "'",
+    "generic-secret-assignment": "api" + "_key" + " = " + '"' + "not-a-real-value-01" + '"',
+    "pem-private-key-header": "-----BEGIN " + "PRIVATE KEY" + "-----",
+    "bearer-token": "Authorization: " + "Bearer " + "abcdefghijklmnopqrstuvwxyz012345",
+    "slack-token": "xox" + "b-" + "0123456789-placeholder",
+    "github-token": "gh" + "p_" + "0123456789abcdefghijklmnopqrstuvwxyz",
+}
+
+SAFE_SAMPLE = "def add(left, right):\n    return left + right\n"
+
+
+def make_repo(tmp: str, files: dict[str, str]) -> Path:
+    repo = Path(tmp) / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, timeout=30)
+    for name, content in files.items():
+        (repo / name).write_text(content, encoding="utf-8")
+    return repo
+
+
+def run_scanner(*paths: str) -> tuple[int, dict]:
+    result = subprocess.run(
+        [sys.executable, str(SCANNER_PATH), *paths],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result.returncode, json.loads(result.stdout)
+
+
+class BlocksUnsafeOutputTests(unittest.TestCase):
+    def test_each_rule_blocks_with_nonzero_exit(self) -> None:
+        for rule, sample in UNSAFE_SAMPLES.items():
+            with self.subTest(rule=rule), tempfile.TemporaryDirectory() as tmp:
+                repo = make_repo(tmp, {"artifact.txt": sample + "\n"})
+                code, report = run_scanner(str(repo))
+                self.assertEqual(code, 1, f"{rule} did not block: {report}")
+                self.assertEqual(
+                    [finding["rule"] for finding in report["findings"]], [rule]
+                )
+                self.assertEqual(report["findings"][0]["path"], "artifact.txt")
+
+    def test_clean_repository_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, {"module.py": SAFE_SAMPLE})
+            code, report = run_scanner(str(repo))
+            self.assertEqual(code, 0, report)
+            self.assertEqual(report["findings"], [])
+
+    def test_finding_never_discloses_matched_content(self) -> None:
+        sample = UNSAFE_SAMPLES["aws-access-key-id"]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, {"artifact.txt": sample + "\n"})
+            code, report = run_scanner(str(repo))
+            self.assertEqual(code, 1)
+            serialized = json.dumps(report)
+            self.assertNotIn(sample, serialized)
+            self.assertNotIn("AKIA" + "IOSFODNN7EXAMPLE", serialized)
+            self.assertEqual(sorted(report["findings"][0]), ["path", "repo", "rule"])
+
+    def test_untracked_but_unignored_artifact_still_blocks(self) -> None:
+        """Publishing operates on the working tree, not just the index."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, {"generated.txt": UNSAFE_SAMPLES["github-token"] + "\n"})
+            code, report = run_scanner(str(repo))
+            self.assertEqual(code, 1, report)
+            self.assertEqual(report["findings"][0]["path"], "generated.txt")
+
+    def test_ignored_runtime_state_is_not_scanned(self) -> None:
+        """Class-3 runtime state is out of scope and must not create noise."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                {
+                    ".gitignore": "runtime/\n",
+                    "module.py": SAFE_SAMPLE,
+                },
+            )
+            (repo / "runtime").mkdir()
+            (repo / "runtime" / "state.txt").write_text(
+                UNSAFE_SAMPLES["slack-token"] + "\n", encoding="utf-8"
+            )
+            code, report = run_scanner(str(repo))
+            self.assertEqual(code, 0, report)
+
+
+class ContainmentTests(unittest.TestCase):
+    def test_non_repository_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code, report = run_scanner(tmp)
+            self.assertEqual(code, 2)
+            self.assertEqual(report["rejected_paths"], [tmp])
+
+    def test_credential_directories_are_forbidden(self) -> None:
+        for name in (".omniroute", ".claude"):
+            with self.subTest(directory=name):
+                self.assertTrue(SCANNER.is_forbidden((Path.home() / name).resolve()))
+                self.assertTrue(
+                    SCANNER.is_forbidden((Path.home() / name / "nested" / "file").resolve())
+                )
+
+    def test_forbidden_directory_is_rejected_even_if_it_is_a_repository(self) -> None:
+        self.assertIsNone(SCANNER.resolve_allowed_repo(str(Path.home() / ".claude")))
+
+    def test_rejection_is_blocking(self) -> None:
+        """An unscannable target must never be reported as a clean pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, {"module.py": SAFE_SAMPLE})
+            unscannable = Path(tmp) / "plain"
+            unscannable.mkdir()
+            code, report = run_scanner(str(repo), str(unscannable))
+            self.assertEqual(code, 2)
+            self.assertEqual(report["findings"], [])
+
+
+class ThisRepositoryTests(unittest.TestCase):
+    def test_repository_itself_is_clean(self) -> None:
+        code, report = run_scanner(str(ROOT))
+        self.assertEqual(code, 0, report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the two acceptance criteria on #7 that #25 left open as *documented but unverifiable*. Both were open for the same reason: the policy described a guarantee that nothing tested.

## Criterion 4 — stable evidence fixtures remain reproducible and are not overwritten by tests/demos

#25 reported "no committed reproducible evidence fixtures were found ... so this criterion cannot yet be verified. The policy is documented, but there is no fixture to test." This PR creates the fixture and the test.

- `evidence/compatibility-baseline.json` — first class-2 published evidence fixture, derived purely from `compatibility-manifest.json`.
- `evidence/EVIDENCE_MANIFEST.json` — SHA-256 of each fixture **and** of the source it derives from, so provenance is checkable without trusting the introducing commit.
- `scripts/build_evidence.py` — the only supported writer. Default mode is a read-only `--check` that regenerates in memory and diffs; writing requires an explicit `--write`. Any caller that runs it without arguments (CI, a test, a demo, an agent) is *structurally* unable to mutate `evidence/`.

Reproducibility is enforced rather than asserted: the generator reads no clock, no environment, and no filesystem state, and machine-local fields (`path`) are projected out — a fixture containing one developer's `/home/<user>/dev/...` could not regenerate byte-identically on a runner. `tests/test_evidence_fixture.py` snapshots the digests of `evidence/`, runs the fixture suite, and fails if any digest moved — testing the "not overwritten by tests" half directly.

## Criterion 5 — secret/PII scan blocks unsafe output

The scan existed but nothing verified that it *blocks* rather than merely reports. `tests/test_secret_scan.py` adds:

- one synthetic fixture per scanner rule, each asserting a non-zero exit;
- a clean fixture asserting exit 0;
- an unscannable target asserting exit 2 — an unreachable path must never be reported as a clean pass;
- a negative-disclosure assertion that the matched string appears nowhere in the emitted report;
- an ignored-runtime-state case confirming class-3 paths stay out of scope.

Unsafe fixtures are synthesized into throwaway git repos under the OS temp dir at run time. No secret-shaped string is committed — that would make this repo's own `drift-check` fail on its own test suite — and sample values are assembled by concatenation so no single line matches a scanner rule.

## CI

- `drift-check` now runs the secret scan **before** verifying evidence, making the scan an ordered pre-publish gate rather than a parallel report.
- The unit suite runs in the `compatibility` job rather than a new standalone job. `tests/test_check_compatibility.py` resolves the manifest's `../verdict-*` paths, so it needs the sibling checkouts that job already provides; a plain-checkout job would have failed on six missing-sibling errors.

## Still open on #7 after this PR

Criterion 3 (runtime/temp outputs ignored portfolio-wide) remains blocked on write access to sibling repositories, as does wiring the scan into sibling CI. Tracked separately with acceptance criteria rather than left implicit — see the status comment on #7.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 30 tests. Passes in a simulated CI layout (ecosystem checkout with sibling directories adjacent), exit 0.
- [x] In a bare worktree without siblings, the only failure is the pre-existing `test_current_manifest_passes` sibling-path resolution — which is why the suite is wired into the `compatibility` job. No new test depends on checkout location.
- [x] `python3 scripts/secret_scan.py .` — 0 findings against this branch, confirming the synthetic samples in the new test module do not trip the scanner.
- [x] `python3 scripts/build_evidence.py` — `status: passed`.
- [x] `git status --porcelain` empty after running all three scripts (the drift gate).
- [x] `git diff --cached --check` — no whitespace errors.

Refs #7.