### PR TITLE
ECO-001: executable ecosystem compatibility and release manifest

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -39,9 +39,30 @@ jobs:
       - name: Validate manifest
         working-directory: verdict-ecosystem
         run: python scripts/check_compatibility.py
+      - name: Verify generated compatibility matrix is current
+        working-directory: verdict-ecosystem
+        run: python scripts/generate_compatibility_matrix.py
       # Run here rather than in ci.yml: tests/test_check_compatibility.py
       # resolves the manifest's `../verdict-*` paths, so it needs the
       # sibling checkouts this job already provides.
       - name: Run unit tests
         working-directory: verdict-ecosystem
         run: python -m unittest discover -s tests -v
+
+  # Released-artifact gate: verifies every repository/docs/registry link the
+  # manifest and docs publish, and installs each published artifact in an
+  # isolated consumer project. Unreleased entries are reported as skipped,
+  # never as passing installs.
+  released-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Verify repository, docs, and registry links
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/verify_links.py
+      - name: Install released artifacts in isolated consumer projects
+        run: python scripts/consumer_smoke.py

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ never implies a higher one.
 ## Documentation
 
 - [Portfolio product strategy](PORTFOLIO_PRODUCT_STRATEGY.md) — product boundary, capability audit, flagship flow, delivery plan, and release gate
+- [Compatibility matrix](docs/COMPATIBILITY_MATRIX.md) — generated from [`compatibility-manifest.json`](compatibility-manifest.json); CI fails on drift, link rot, or a published artifact that does not install
 - [Core repository](https://github.com/mrnicholasbcarter-code/verdict-core) — implementation workstream; installation claims require current default-branch and clean-install verification
 - [Node repository](https://github.com/mrnicholasbcarter-code/verdict-node) — typed integration boundary
 - [Cockpit repository](https://github.com/mrnicholasbcarter-code/verdict-cockpit) — visual portfolio surface

--- a/compatibility-manifest.json
+++ b/compatibility-manifest.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": "2",
+  "schema_version": "3",
   "contract_version": "1",
   "policy_version": "1",
   "validation_scope": "local-source-directories",
-  "evidence_timestamp": "2026-08-18T00:00:00Z",
+  "evidence_timestamp": "2026-08-20T00:00:00Z",
   "release_train": {
     "id": "rel-001-partial-2026-08-18",
     "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md",
@@ -40,6 +40,7 @@
       "release_train_pin": "bc93e455ed4dd7f2c369ff66132b152cfa0da04f",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-core",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-core",
+      "legacy_aliases": [],
       "test_command": "uv run pytest -q",
       "status": "required"
     },
@@ -63,6 +64,7 @@
       "release_train_pin": "48f8189c0e69bd915f1a1dfd7beec7e5e3e05e62",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-node",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-node",
+      "legacy_aliases": [],
       "test_command": "npm test",
       "status": "required"
     },
@@ -82,10 +84,26 @@
       "provider_compatibility": ["provider-agnostic-receipts"],
       "maturity": "alpha",
       "support_level": "experimental",
-      "evidence_timestamp": "2026-08-18T00:00:00Z",
+      "evidence_timestamp": "2026-08-20T00:00:00Z",
       "release_train_pin": "65477ec4a487d5893c988802e559a823202018e7",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-risk",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-risk",
+      "legacy_aliases": [
+        {
+          "name": "llm-gate-risk",
+          "kind": "package",
+          "replacement": "verdict-risk",
+          "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-risk",
+          "sunset_date": "2026-12-31"
+        },
+        {
+          "name": "llm-gate-risk-benchmark",
+          "kind": "cli",
+          "replacement": "verdict-risk-benchmark",
+          "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-risk",
+          "sunset_date": "2026-12-31"
+        }
+      ],
       "test_command": "uv run pytest -q",
       "status": "required"
     },
@@ -109,6 +127,7 @@
       "release_train_pin": "d393ca0a829658e5b7078ed34dddde2aa9830114",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-strategy",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-strategy",
+      "legacy_aliases": [],
       "test_command": "uv run pytest -q",
       "status": "required"
     },
@@ -128,10 +147,19 @@
       "provider_compatibility": ["provider-agnostic-receipts"],
       "maturity": "alpha",
       "support_level": "experimental",
-      "evidence_timestamp": "2026-08-18T00:00:00Z",
+      "evidence_timestamp": "2026-08-20T00:00:00Z",
       "release_train_pin": "3c89fb8d4dca086a4ac05e476177243148279a91",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-backtest",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-backtest",
+      "legacy_aliases": [
+        {
+          "name": "llm-gate-backtest",
+          "kind": "package",
+          "replacement": "verdict-backtest",
+          "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-backtest",
+          "sunset_date": "2026-12-31"
+        }
+      ],
       "test_command": "uv run pytest -q",
       "status": "required"
     },
@@ -155,6 +183,7 @@
       "release_train_pin": "4dbdf403adfbd68f97ed61a10aae64835c0a2e21",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-cockpit",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-cockpit",
+      "legacy_aliases": [],
       "test_command": "npm test",
       "status": "required"
     },
@@ -178,6 +207,7 @@
       "release_train_pin": "e0743cea8c9f63a0cd4bbf0d2177ff4c442e03cb",
       "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-ecosystem",
       "rollback_instructions": "docs/COMPATIBILITY_ROLLBACK.md#verdict-ecosystem",
+      "legacy_aliases": [],
       "test_command": "python3 scripts/check_compatibility.py",
       "status": "required"
     }

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,0 +1,42 @@
+# Verdict Ecosystem Compatibility Matrix
+
+> **GENERATED FILE — do not edit by hand.**
+> Source of truth: [`compatibility-manifest.json`](../compatibility-manifest.json).
+> Regenerate with `python3 scripts/generate_compatibility_matrix.py --write`;
+> CI fails if this file drifts from the manifest.
+
+Release train `rel-001-partial-2026-08-18` · schema `3` · contract `1` · policy `1` · validation scope `local-source-directories` · evidence timestamp `2026-08-20T00:00:00Z`
+
+## Repositories
+
+| Repository | Package | Import | CLI | Version | Publication | Registry | Runtime | Maturity | Support | Evidence date | Release-train pin |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| [verdict-core](https://github.com/mrnicholasbcarter-code/verdict-core) | `verdict-core` | `verdict` | `verdict` | `0.1.0` | source-only — no released artifact | **not published** | python >=3.10 | alpha | experimental | 2026-08-18T00:00:00Z | `bc93e455ed4dd7f2c369ff66132b152cfa0da04f` |
+| [verdict-node](https://github.com/mrnicholasbcarter-code/verdict-node) | `@bodanglin/verdict-node` | `@bodanglin/verdict-node` | — | `0.1.0` | published | [registry](https://www.npmjs.com/package/@bodanglin/verdict-node) | node >=18 | alpha | experimental | 2026-08-18T00:00:00Z | `48f8189c0e69bd915f1a1dfd7beec7e5e3e05e62` |
+| [verdict-risk](https://github.com/mrnicholasbcarter-code/verdict-risk) | `llm-gate-risk` | `trade_risk_engine` | `verdict-risk-benchmark` | `0.1.0` | source-only — no released artifact | **not published** | python >=3.10 | alpha | experimental | 2026-08-20T00:00:00Z | `65477ec4a487d5893c988802e559a823202018e7` |
+| [verdict-strategy](https://github.com/mrnicholasbcarter-code/verdict-strategy) | `verdict-edge` | `edge_mining_framework` | — | `0.1.0` | source-only — no released artifact | **not published** | python >=3.10 | alpha | experimental | 2026-08-18T00:00:00Z | `d393ca0a829658e5b7078ed34dddde2aa9830114` |
+| [verdict-backtest](https://github.com/mrnicholasbcarter-code/verdict-backtest) | `llm-gate-backtest` | `backtest_harness` | — | `0.1.0` | source-only — no released artifact | **not published** | python >=3.10 | alpha | experimental | 2026-08-20T00:00:00Z | `3c89fb8d4dca086a4ac05e476177243148279a91` |
+| [verdict-cockpit](https://github.com/mrnicholasbcarter-code/verdict-cockpit) | `verdict-cockpit` | — | — | `0.1.0` | private application — not distributed | **not published** | node unspecified | alpha | experimental | 2026-08-18T00:00:00Z | `4dbdf403adfbd68f97ed61a10aae64835c0a2e21` |
+| [verdict-ecosystem](https://github.com/mrnicholasbcarter-code/verdict-ecosystem) | `verdict-ecosystem` | — | — | **unreleased** | documentation only — not distributed | **not published** | python unspecified | alpha | experimental | 2026-08-18T00:00:00Z | `e0743cea8c9f63a0cd4bbf0d2177ff4c442e03cb` |
+
+Rows marked **not published** or **unreleased** have no released artifact; they are validated from pinned local source only.
+
+## Legacy names and migration deadlines
+
+| Repository | Legacy name | Kind | Replacement | Sunset date | Migration |
+|---|---|---|---|---|---|
+| verdict-risk | `llm-gate-risk` | package | `verdict-risk` | 2026-12-31 | [migration](../docs/COMPATIBILITY_MIGRATION.md#verdict-risk) |
+| verdict-risk | `llm-gate-risk-benchmark` | cli | `verdict-risk-benchmark` | 2026-12-31 | [migration](../docs/COMPATIBILITY_MIGRATION.md#verdict-risk) |
+| verdict-backtest | `llm-gate-backtest` | package | `verdict-backtest` | 2026-12-31 | [migration](../docs/COMPATIBILITY_MIGRATION.md#verdict-backtest) |
+
+## Deferred checks
+
+| Check | Blocked by |
+|---|---|
+| `schema-hashes` | https://github.com/mrnicholasbcarter-code/verdict-core/issues/220 |
+| `cross-repository-contract-smoke-tests` | https://github.com/mrnicholasbcarter-code/verdict-node/issues/31 |
+
+## Migration and rollback
+
+- Migration guide: [COMPATIBILITY_MIGRATION.md](../docs/COMPATIBILITY_MIGRATION.md)
+- Rollback guide: [COMPATIBILITY_ROLLBACK.md](../docs/COMPATIBILITY_ROLLBACK.md)

--- a/docs/COMPATIBILITY_MIGRATION.md
+++ b/docs/COMPATIBILITY_MIGRATION.md
@@ -23,6 +23,10 @@ and [`verdict-node#31`](https://github.com/mrnicholasbcarter-code/verdict-node/i
 A successful checker run proves that the manifest is structurally valid and
 that its local directories exist. It does not prove registry publication,
 artifact integrity, schema compatibility, or cross-repository behavior.
+Registry publication and link integrity are verified separately by the
+`released-artifacts` CI job (`scripts/verify_links.py` and
+`scripts/consumer_smoke.py`), which installs each published artifact in an
+isolated consumer project and marks unreleased entries as skipped.
 
 ## verdict-core
 
@@ -41,7 +45,10 @@ it does not transfer policy authority from Verdict Core.
 
 Use the `trade_risk_engine` Python import. The primary CLI is
 `verdict-risk-benchmark`; the legacy `llm-gate-risk-benchmark` alias remains in
-source but is not the canonical manifest name. No published registry artifact
+source but is not the canonical manifest name. The legacy `llm-gate-risk`
+package name and the `llm-gate-risk-benchmark` CLI alias are recorded in the
+manifest with a sunset date of 2026-12-31; migrate to `verdict-risk` and
+`verdict-risk-benchmark` before that date. No published registry artifact
 was verified for this release train.
 
 ## verdict-strategy
@@ -53,7 +60,10 @@ explicit mapping during migration. No published registry artifact was verified.
 ## verdict-backtest
 
 Use the `backtest_harness` Python import from the `llm-gate-backtest` source
-distribution. No canonical CLI or published registry artifact was verified.
+distribution. The legacy `llm-gate-backtest` package name is recorded in the
+manifest with a sunset date of 2026-12-31; migrate to `verdict-backtest`
+before that date. No canonical CLI or published registry artifact was
+verified.
 
 ## verdict-cockpit
 

--- a/evidence/EVIDENCE_MANIFEST.json
+++ b/evidence/EVIDENCE_MANIFEST.json
@@ -2,7 +2,7 @@
   "artifacts": [
     {
       "path": "evidence/compatibility-baseline.json",
-      "sha256": "502244e922a719f199c23545fa73ae497abae96e14050dd36667b390188eb8a6"
+      "sha256": "132ec0bf960bd79aec0858ad676f247ed3dfa2250499f44bd85643521c9751b4"
     }
   ],
   "class": "2-stable-published-evidence",
@@ -10,6 +10,6 @@
   "policy": "docs/ARTIFACT_HYGIENE_POLICY.md",
   "source": {
     "path": "compatibility-manifest.json",
-    "sha256": "f73642a54733d00ba27a4521af0f065ca7a647b68f2c40c1614fe8287be2b4f6"
+    "sha256": "676e32e874a805910c3a478a0571b4d9c9b84e00f3f3e5f8f4fd8a59b8678e83"
   }
 }

--- a/evidence/compatibility-baseline.json
+++ b/evidence/compatibility-baseline.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "1",
-  "evidence_timestamp": "2026-08-18T00:00:00Z",
+  "evidence_timestamp": "2026-08-20T00:00:00Z",
   "policy_version": "1",
   "release_train": {
     "deferred_checks": [
@@ -103,5 +103,5 @@
       "support_level": "experimental"
     }
   ],
-  "schema_version": "2"
+  "schema_version": "3"
 }

--- a/scripts/check_compatibility.py
+++ b/scripts/check_compatibility.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = "3"
 VALIDATION_SCOPE = "local-source-directories"
 REQUIRED_IDS = {
     "verdict-core",
@@ -39,11 +39,14 @@ REQUIRED_FIELDS = {
     "support_level",
     "evidence_timestamp",
     "release_train_pin",
+    "legacy_aliases",
     "migration_instructions",
     "rollback_instructions",
     "test_command",
     "status",
 }
+LEGACY_ALIAS_FIELDS = {"name", "kind", "replacement", "migration_instructions", "sunset_date"}
+LEGACY_ALIAS_KINDS = {"package", "import", "cli", "repository"}
 PUBLICATION_STATUSES = {
     "published",
     "source-only",
@@ -205,6 +208,47 @@ def validate_repository(
 
     validate_instruction(root, item["migration_instructions"], f"{prefix}.migration_instructions", errors)
     validate_instruction(root, item["rollback_instructions"], f"{prefix}.rollback_instructions", errors)
+    validate_legacy_aliases(root, item["legacy_aliases"], f"{prefix}.legacy_aliases", errors)
+
+
+def validate_legacy_aliases(root: Path, value: object, field: str, errors: list[str]) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{field} must be an array")
+        return
+    seen: set[str] = set()
+    for index, entry in enumerate(value):
+        prefix = f"{field}[{index}]"
+        if not isinstance(entry, dict) or set(entry) != LEGACY_ALIAS_FIELDS:
+            errors.append(f"{prefix} must contain exactly {sorted(LEGACY_ALIAS_FIELDS)}")
+            continue
+        name = entry["name"]
+        if not isinstance(name, str) or not re.fullmatch(r"[a-z][a-z0-9-]+", name):
+            errors.append(f"{prefix}.name must be a safe legacy identifier")
+            continue
+        if name in seen:
+            errors.append(f"{field}: duplicate legacy alias: {name}")
+        seen.add(name)
+        if entry["kind"] not in LEGACY_ALIAS_KINDS:
+            errors.append(f"{prefix}.kind must be one of {sorted(LEGACY_ALIAS_KINDS)}")
+        replacement = entry["replacement"]
+        if (
+            not isinstance(replacement, str)
+            or not re.fullmatch(r"[a-z][a-z0-9-]+", replacement)
+            or replacement == name
+        ):
+            errors.append(f"{prefix}.replacement must be a canonical name differing from the alias")
+        validate_instruction(root, entry["migration_instructions"], f"{prefix}.migration_instructions", errors)
+        validate_sunset_date(entry["sunset_date"], f"{prefix}.sunset_date", errors)
+
+
+def validate_sunset_date(value: object, field: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        errors.append(f"{field} must be a calendar date (YYYY-MM-DD)")
+        return
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        errors.append(f"{field} must be a calendar date (YYYY-MM-DD)")
 
 
 def validate_release_train(root: Path, value: object, errors: list[str]) -> None:

--- a/scripts/consumer_smoke.py
+++ b/scripts/consumer_smoke.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Cross-language contract matrix: install released artifacts in isolated consumers.
+
+For every manifest entry with `publication_status: "published"`, this script
+creates an isolated throwaway consumer project (a temp directory that is not
+a workspace member), installs the exact pinned `artifact_version` from the
+public registry, asserts the installed version matches the manifest, and
+runs a minimal import snippet against the released artifact.
+
+Entries without a released artifact are *visibly marked as skipped* with the
+reason recorded in the report — they are never silently treated as passing
+installs. Planning (`plan_actions`) is pure and offline-testable; only the
+executors touch the network.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_TIMEOUT_SECONDS = 300
+
+
+def infer_ecosystem(repo: dict) -> str:
+    runtimes = set(repo["runtime_constraints"])
+    if "node" in runtimes:
+        return "npm"
+    if "python" in runtimes:
+        return "pypi"
+    return "unknown"
+
+
+def plan_actions(manifest: dict) -> list[dict[str, object]]:
+    actions: list[dict[str, object]] = []
+    for repo in manifest["repositories"]:
+        ecosystem = infer_ecosystem(repo)
+        if repo["publication_status"] != "published":
+            actions.append(
+                {
+                    "id": repo["id"],
+                    "ecosystem": ecosystem,
+                    "action": "skipped",
+                    "reason": f"no released artifact (publication_status={repo['publication_status']})",
+                }
+            )
+            continue
+        actions.append(
+            {
+                "id": repo["id"],
+                "ecosystem": ecosystem,
+                "action": "install",
+                "package": repo["package"],
+                "version": repo["artifact_version"],
+                "import_name": repo["import_name"],
+            }
+        )
+    return actions
+
+
+def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command, cwd=cwd, capture_output=True, text=True, timeout=INSTALL_TIMEOUT_SECONDS
+    )
+
+
+def install_npm(action: dict[str, object], consumer: Path) -> list[str]:
+    package = str(action["package"])
+    version = str(action["version"])
+    (consumer / "package.json").write_text(
+        json.dumps({"name": "verdict-consumer-smoke", "private": True}) + "\n",
+        encoding="utf-8",
+    )
+    install = run(
+        ["npm", "install", f"{package}@{version}", "--no-audit", "--no-fund", "--loglevel=error"],
+        consumer,
+    )
+    if install.returncode != 0:
+        return [f"npm install failed: {install.stderr.strip()[:500]}"]
+
+    installed_manifest = consumer / "node_modules" / package / "package.json"
+    installed_version = json.loads(installed_manifest.read_text(encoding="utf-8"))["version"]
+    problems: list[str] = []
+    if installed_version != version:
+        problems.append(f"installed version {installed_version} != manifest version {version}")
+
+    snippet = (
+        f"import({json.dumps(package)}).then((module) => {{"
+        " if (Object.keys(module).length === 0) { console.error('no exports'); process.exit(1); }"
+        " }).catch((error) => { console.error(String(error)); process.exit(1); });"
+    )
+    imported = run(["node", "-e", snippet], consumer)
+    if imported.returncode != 0:
+        problems.append(f"import snippet failed: {imported.stderr.strip()[:500]}")
+    return problems
+
+
+def install_pypi(action: dict[str, object], consumer: Path) -> list[str]:
+    package = str(action["package"])
+    version = str(action["version"])
+    venv = consumer / "venv"
+    created = run([sys.executable, "-m", "venv", str(venv)], consumer)
+    if created.returncode != 0:
+        return [f"venv creation failed: {created.stderr.strip()[:500]}"]
+    pip = venv / "bin" / "pip"
+    python = venv / "bin" / "python"
+    installed = run([str(pip), "install", "--quiet", f"{package}=={version}"], consumer)
+    if installed.returncode != 0:
+        return [f"pip install failed: {installed.stderr.strip()[:500]}"]
+    import_name = action["import_name"]
+    if not import_name:
+        return ["published Python artifact has no import_name to smoke-test"]
+    imported = run([str(python), "-c", f"import {import_name}"], consumer)
+    if imported.returncode != 0:
+        return [f"import snippet failed: {imported.stderr.strip()[:500]}"]
+    return []
+
+
+def execute(action: dict[str, object]) -> dict[str, object]:
+    result = dict(action)
+    if action["action"] == "skipped":
+        result["outcome"] = "skipped"
+        return result
+    with tempfile.TemporaryDirectory(prefix=f"consumer-{action['id']}-") as tmp:
+        consumer = Path(tmp)
+        if action["ecosystem"] == "npm":
+            problems = install_npm(action, consumer)
+        elif action["ecosystem"] == "pypi":
+            problems = install_pypi(action, consumer)
+        else:
+            problems = [f"unsupported ecosystem: {action['ecosystem']}"]
+    result["outcome"] = "failed" if problems else "installed"
+    if problems:
+        result["problems"] = problems
+    return result
+
+
+def main() -> int:
+    manifest = json.loads((ROOT / "compatibility-manifest.json").read_text(encoding="utf-8"))
+    results = [execute(action) for action in plan_actions(manifest)]
+    failed = [result for result in results if result["outcome"] == "failed"]
+    report = {
+        "status": "failed" if failed else "passed",
+        "installed": sum(1 for result in results if result["outcome"] == "installed"),
+        "skipped_unreleased": sum(1 for result in results if result["outcome"] == "skipped"),
+        "matrix": results,
+    }
+    print(json.dumps(report, indent=2))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_compatibility_matrix.py
+++ b/scripts/generate_compatibility_matrix.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate the human compatibility matrix from compatibility-manifest.json.
+
+The committed `docs/COMPATIBILITY_MATRIX.md` is a pure function of the
+manifest: no timestamps of generation, no environment probing, no absolute
+paths, so the same commit renders byte-identical output on any machine.
+The default mode is `--check`, which regenerates the matrix in memory and
+compares it against the committed file, so CI cannot mutate the document.
+Only `--write` writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "compatibility-manifest.json"
+TARGET = ROOT / "docs" / "COMPATIBILITY_MATRIX.md"
+
+PUBLICATION_LABELS = {
+    "published": "published",
+    "source-only": "source-only — no released artifact",
+    "private-application": "private application — not distributed",
+    "documentation-only": "documentation only — not distributed",
+}
+
+HEADER = """# Verdict Ecosystem Compatibility Matrix
+
+> **GENERATED FILE — do not edit by hand.**
+> Source of truth: [`compatibility-manifest.json`](../compatibility-manifest.json).
+> Regenerate with `python3 scripts/generate_compatibility_matrix.py --write`;
+> CI fails if this file drifts from the manifest.
+"""
+
+
+def code(value: object) -> str:
+    return f"`{value}`" if value is not None else "—"
+
+
+def render(manifest: dict) -> str:
+    train = manifest["release_train"]
+    lines = [HEADER]
+    lines.append(
+        f"Release train {code(train['id'])} · schema {code(manifest['schema_version'])}"
+        f" · contract {code(manifest['contract_version'])}"
+        f" · policy {code(manifest['policy_version'])}"
+        f" · validation scope {code(manifest['validation_scope'])}"
+        f" · evidence timestamp {code(manifest['evidence_timestamp'])}"
+    )
+    lines.append("")
+    lines.append("## Repositories")
+    lines.append("")
+    lines.append(
+        "| Repository | Package | Import | CLI | Version | Publication | Registry |"
+        " Runtime | Maturity | Support | Evidence date | Release-train pin |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|")
+    for repo in manifest["repositories"]:
+        runtime = ", ".join(
+            f"{name} {constraint}" for name, constraint in sorted(repo["runtime_constraints"].items())
+        )
+        registry = (
+            f"[registry]({repo['registry_url']})" if repo["registry_url"] else "**not published**"
+        )
+        version = repo["artifact_version"]
+        version_cell = "**unreleased**" if version == "unreleased" else code(version)
+        lines.append(
+            f"| [{repo['id']}]({repo['repository_url']}) | {code(repo['package'])} |"
+            f" {code(repo['import_name'])} | {code(repo['cli_name'])} | {version_cell} |"
+            f" {PUBLICATION_LABELS[repo['publication_status']]} | {registry} | {runtime} |"
+            f" {repo['maturity']} | {repo['support_level']} | {repo['evidence_timestamp']} |"
+            f" {code(repo['release_train_pin'])} |"
+        )
+    lines.append("")
+    lines.append(
+        "Rows marked **not published** or **unreleased** have no released artifact;"
+        " they are validated from pinned local source only."
+    )
+
+    lines.append("")
+    lines.append("## Legacy names and migration deadlines")
+    lines.append("")
+    alias_rows = [
+        (repo["id"], alias) for repo in manifest["repositories"] for alias in repo["legacy_aliases"]
+    ]
+    if alias_rows:
+        lines.append("| Repository | Legacy name | Kind | Replacement | Sunset date | Migration |")
+        lines.append("|---|---|---|---|---|---|")
+        for repo_id, alias in alias_rows:
+            lines.append(
+                f"| {repo_id} | {code(alias['name'])} | {alias['kind']} |"
+                f" {code(alias['replacement'])} | {alias['sunset_date']} |"
+                f" [migration](../{alias['migration_instructions']}) |"
+            )
+    else:
+        lines.append("No legacy aliases are recorded in the manifest.")
+
+    lines.append("")
+    lines.append("## Deferred checks")
+    lines.append("")
+    lines.append("| Check | Blocked by |")
+    lines.append("|---|---|")
+    for check in train["deferred_checks"]:
+        lines.append(f"| {code(check['name'])} | {check['blocked_by']} |")
+
+    lines.append("")
+    lines.append("## Migration and rollback")
+    lines.append("")
+    migration = train["migration_instructions"]
+    rollback = train["rollback_instructions"]
+    lines.append(f"- Migration guide: [{Path(migration).name}](../{migration})")
+    lines.append(f"- Rollback guide: [{Path(rollback).name}](../{rollback})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="regenerate docs/COMPATIBILITY_MATRIX.md (the only mode that writes)",
+    )
+    args = parser.parse_args()
+
+    expected = render(json.loads(SOURCE.read_text(encoding="utf-8")))
+    if args.write:
+        changed = not TARGET.exists() or TARGET.read_text(encoding="utf-8") != expected
+        if changed:
+            TARGET.write_text(expected, encoding="utf-8")
+        print(json.dumps({"mode": "write", "changed": changed}, indent=2))
+        return 0
+
+    if not TARGET.exists():
+        print(json.dumps({"mode": "check", "status": "failed", "problems": ["docs/COMPATIBILITY_MATRIX.md missing"]}, indent=2))
+        return 1
+    actual = TARGET.read_text(encoding="utf-8")
+    problems = (
+        []
+        if actual == expected
+        else ["docs/COMPATIBILITY_MATRIX.md is stale or hand-edited; regenerate with scripts/generate_compatibility_matrix.py --write"]
+    )
+    print(json.dumps({"mode": "check", "status": "failed" if problems else "passed", "problems": problems}, indent=2))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_links.py
+++ b/scripts/verify_links.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Verify every repository, docs, and registry link the ecosystem publishes.
+
+Scope of network access: HTTPS GET requests to the exact URLs recorded in
+`compatibility-manifest.json` and found in `README.md` and `docs/*.md`,
+plus a registry version lookup for each *published* artifact so the
+manifest's `artifact_version` is checked against the registry's immutable
+version list. No credentials are read except an optional `GITHUB_TOKEN`
+environment variable, sent only to `github.com`/`api.github.com` to avoid
+anonymous rate limits. Nothing is written.
+
+URL collection is pure and offline-testable (`collect_manifest_urls`,
+`collect_markdown_urls`); only `main()` touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKDOWN_SOURCES = ("README.md", "docs")
+URL_PATTERN = re.compile(r"https://[^\s)\">\]`]+")
+TIMEOUT_SECONDS = 20
+USER_AGENT = "verdict-ecosystem-link-check"
+
+
+def collect_manifest_urls(manifest: dict) -> set[str]:
+    urls: set[str] = set()
+    for check in manifest["release_train"]["deferred_checks"]:
+        urls.add(check["blocked_by"])
+    for repo in manifest["repositories"]:
+        urls.add(repo["repository_url"])
+        if repo["registry_url"]:
+            urls.add(repo["registry_url"])
+    return urls
+
+
+def collect_markdown_urls(root: Path) -> set[str]:
+    urls: set[str] = set()
+    paths: list[Path] = []
+    for source in MARKDOWN_SOURCES:
+        candidate = root / source
+        if candidate.is_dir():
+            paths.extend(sorted(candidate.glob("*.md")))
+        elif candidate.is_file():
+            paths.append(candidate)
+    for path in paths:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for match in URL_PATTERN.findall(text):
+            urls.add(match.rstrip(".,;:!?"))
+    return urls
+
+
+def registry_probes(manifest: dict) -> list[dict[str, str]]:
+    """Immutable-version lookups for every published artifact."""
+    probes: list[dict[str, str]] = []
+    for repo in manifest["repositories"]:
+        if repo["publication_status"] != "published":
+            continue
+        host = urlparse(repo["registry_url"]).hostname or ""
+        package = str(repo["package"])
+        if host.endswith("npmjs.com"):
+            url = "https://registry.npmjs.org/" + quote(package, safe="@")
+        elif host.endswith("pypi.org"):
+            url = f"https://pypi.org/pypi/{quote(package)}/json"
+        else:
+            probes.append({"id": repo["id"], "url": repo["registry_url"], "error": f"unsupported registry host: {host}"})
+            continue
+        probes.append({"id": repo["id"], "url": url, "version": str(repo["artifact_version"])})
+    return probes
+
+
+def probe_url(url: str) -> str:
+    """npmjs.com package pages 403 scripted GETs; probe the registry API
+    for the same package name instead — it proves the same availability."""
+    parsed = urlparse(url)
+    if parsed.hostname in {"www.npmjs.com", "npmjs.com"} and parsed.path.startswith("/package/"):
+        name = parsed.path[len("/package/"):].strip("/")
+        return "https://registry.npmjs.org/" + quote(name, safe="@")
+    return url
+
+
+def fetch(url: str) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    hostname = urlparse(url).hostname or ""
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token and hostname in {"github.com", "api.github.com"}:
+        request.add_header("Authorization", "Bearer " + token)
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        return response.status, response.read()
+
+
+def check_url(url: str, attempts: int = 2) -> str | None:
+    target = probe_url(url)
+    for attempt in range(attempts):
+        try:
+            status, _ = fetch(target)
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            if attempt + 1 == attempts:
+                return f"{url}: {exc}"
+            continue
+        if 200 <= status < 400:
+            return None
+        if attempt + 1 == attempts:
+            return f"{url}: HTTP {status}"
+    return f"{url}: unreachable"
+
+
+def check_registry_version(probe: dict[str, str]) -> str | None:
+    if "error" in probe:
+        return f"{probe['id']}: {probe['error']}"
+    try:
+        status, body = fetch(probe["url"])
+        payload = json.loads(body)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return f"{probe['id']}: {probe['url']}: {exc}"
+    if status != 200:
+        return f"{probe['id']}: {probe['url']}: HTTP {status}"
+    versions = payload.get("versions") or payload.get("releases") or {}
+    if probe["version"] not in versions:
+        return (
+            f"{probe['id']}: version {probe['version']} not found in registry"
+            f" (available: {sorted(versions)})"
+        )
+    return None
+
+
+def main() -> int:
+    manifest = json.loads((ROOT / "compatibility-manifest.json").read_text(encoding="utf-8"))
+    urls = sorted(collect_manifest_urls(manifest) | collect_markdown_urls(ROOT))
+    failures = [problem for url in urls if (problem := check_url(url))]
+    probes = registry_probes(manifest)
+    failures.extend(problem for probe in probes if (problem := check_registry_version(probe)))
+    report = {
+        "status": "failed" if failures else "passed",
+        "checked_urls": len(urls),
+        "registry_version_probes": [probe.get("url") for probe in probes],
+        "failures": failures,
+    }
+    print(json.dumps(report, indent=2))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_compatibility.py
+++ b/tests/test_check_compatibility.py
@@ -98,6 +98,56 @@ class CompatibilityManifestTests(unittest.TestCase):
         )
         self.assertTrue(any("registry_url is required" in error for error in errors))
 
+    def test_missing_legacy_aliases_field_fails(self) -> None:
+        errors = self.validate(lambda value: value["repositories"][0].pop("legacy_aliases"))
+        self.assertTrue(any("missing fields" in error for error in errors))
+
+    def test_legacy_alias_requires_exact_fields(self) -> None:
+        errors = self.validate(
+            lambda value: value["repositories"][0].update(legacy_aliases=[{"name": "old-name"}])
+        )
+        self.assertTrue(any("must contain exactly" in error for error in errors))
+
+    def test_legacy_alias_invalid_kind_and_sunset_fail(self) -> None:
+        alias = {
+            "name": "llm-gate-core",
+            "kind": "branding",
+            "replacement": "verdict-core",
+            "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-core",
+            "sunset_date": "someday",
+        }
+        errors = self.validate(
+            lambda value: value["repositories"][0].update(legacy_aliases=[alias])
+        )
+        self.assertTrue(any(".kind must be one of" in error for error in errors))
+        self.assertTrue(any("calendar date" in error for error in errors))
+
+    def test_legacy_alias_replacement_must_differ(self) -> None:
+        alias = {
+            "name": "same-name",
+            "kind": "package",
+            "replacement": "same-name",
+            "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-core",
+            "sunset_date": "2026-12-31",
+        }
+        errors = self.validate(
+            lambda value: value["repositories"][0].update(legacy_aliases=[alias])
+        )
+        self.assertTrue(any("differing from the alias" in error for error in errors))
+
+    def test_duplicate_legacy_alias_fails(self) -> None:
+        alias = {
+            "name": "llm-gate-core",
+            "kind": "package",
+            "replacement": "verdict-core",
+            "migration_instructions": "docs/COMPATIBILITY_MIGRATION.md#verdict-core",
+            "sunset_date": "2026-12-31",
+        }
+        errors = self.validate(
+            lambda value: value["repositories"][0].update(legacy_aliases=[alias, dict(alias)])
+        )
+        self.assertTrue(any("duplicate legacy alias" in error for error in errors))
+
     def test_deferred_checks_and_blockers_are_fixed(self) -> None:
         errors = self.validate(
             lambda value: value["release_train"]["deferred_checks"].clear()

--- a/tests/test_release_checks.py
+++ b/tests/test_release_checks.py
@@ -1,0 +1,105 @@
+"""Offline tests for the generated matrix, link collection, and consumer planning.
+
+These tests never touch the network: they exercise the pure planning and
+rendering functions plus the committed generated document.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MATRIX = load("generate_compatibility_matrix")
+LINKS = load("verify_links")
+SMOKE = load("consumer_smoke")
+MANIFEST = json.loads((ROOT / "compatibility-manifest.json").read_text(encoding="utf-8"))
+
+
+class MatrixGenerationTests(unittest.TestCase):
+    def test_committed_matrix_matches_manifest(self) -> None:
+        expected = MATRIX.render(MANIFEST)
+        actual = (ROOT / "docs" / "COMPATIBILITY_MATRIX.md").read_text(encoding="utf-8")
+        self.assertEqual(actual, expected)
+
+    def test_rendering_is_deterministic(self) -> None:
+        self.assertEqual(MATRIX.render(MANIFEST), MATRIX.render(copy.deepcopy(MANIFEST)))
+
+    def test_unreleased_components_are_visibly_marked(self) -> None:
+        rendered = MATRIX.render(MANIFEST)
+        self.assertIn("**not published**", rendered)
+        self.assertIn("**unreleased**", rendered)
+        self.assertIn("GENERATED FILE", rendered)
+
+    def test_legacy_aliases_render_with_sunset_dates(self) -> None:
+        rendered = MATRIX.render(MANIFEST)
+        self.assertIn("llm-gate-risk-benchmark", rendered)
+        self.assertIn("Sunset date", rendered)
+
+
+class LinkCollectionTests(unittest.TestCase):
+    def test_manifest_urls_cover_repositories_registries_and_blockers(self) -> None:
+        urls = LINKS.collect_manifest_urls(MANIFEST)
+        self.assertIn("https://github.com/mrnicholasbcarter-code/verdict-core", urls)
+        self.assertIn("https://www.npmjs.com/package/@bodanglin/verdict-node", urls)
+        self.assertTrue(any("/issues/" in url for url in urls))
+
+    def test_markdown_urls_are_collected_and_trimmed(self) -> None:
+        urls = LINKS.collect_markdown_urls(ROOT)
+        self.assertTrue(urls)
+        self.assertTrue(all(url.startswith("https://") for url in urls))
+        self.assertFalse(any(url.endswith((".", ",", ")")) for url in urls))
+
+    def test_npm_page_probes_registry_api(self) -> None:
+        probed = LINKS.probe_url("https://www.npmjs.com/package/@bodanglin/verdict-node")
+        self.assertEqual(probed, "https://registry.npmjs.org/@bodanglin%2Fverdict-node")
+        untouched = LINKS.probe_url("https://github.com/mrnicholasbcarter-code/verdict-core")
+        self.assertEqual(untouched, "https://github.com/mrnicholasbcarter-code/verdict-core")
+
+    def test_registry_probe_pins_published_version(self) -> None:
+        probes = LINKS.registry_probes(MANIFEST)
+        self.assertEqual(len(probes), 1)
+        self.assertEqual(probes[0]["id"], "verdict-node")
+        self.assertEqual(probes[0]["version"], "0.1.0")
+
+
+class ConsumerPlanTests(unittest.TestCase):
+    def test_plan_covers_all_repositories(self) -> None:
+        actions = SMOKE.plan_actions(MANIFEST)
+        self.assertEqual(len(actions), 7)
+
+    def test_only_published_artifacts_are_installed(self) -> None:
+        actions = SMOKE.plan_actions(MANIFEST)
+        installs = [action for action in actions if action["action"] == "install"]
+        self.assertEqual([action["id"] for action in installs], ["verdict-node"])
+        self.assertEqual(installs[0]["version"], "0.1.0")
+
+    def test_unreleased_entries_are_skipped_with_reason(self) -> None:
+        actions = SMOKE.plan_actions(MANIFEST)
+        skipped = [action for action in actions if action["action"] == "skipped"]
+        self.assertEqual(len(skipped), 6)
+        self.assertTrue(all("no released artifact" in str(action["reason"]) for action in skipped))
+
+    def test_cross_language_matrix_spans_python_and_node(self) -> None:
+        ecosystems = {action["ecosystem"] for action in SMOKE.plan_actions(MANIFEST)}
+        self.assertIn("npm", ecosystems)
+        self.assertIn("pypi", ecosystems)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #1 — executable ecosystem compatibility and release manifest.

Head commit for all evidence below: `862d563ab8681747a515b2cda8a5c59df98905e0`.

## Per-criterion evidence

1. **One machine-readable manifest** — `compatibility-manifest.json` (schema v3) lists all seven repositories with canonical package/import/CLI names, registry URL, latest verified version, contract/policy versions, and maturity/support level. `scripts/check_compatibility.py` enforces the schema; local run: `"status": "passed"`, 0 warnings.
2. **Human matrix generated from the manifest** — `docs/COMPATIBILITY_MATRIX.md` is rendered by `scripts/generate_compatibility_matrix.py` as a pure function of the manifest (no timestamps, no environment). Default mode is a drift check; CI step "Verify generated compatibility matrix is current" fails on hand edits or staleness. Test: `tests/test_release_checks.py::MatrixGenerationTests`.
3. **CI verifies every repository/docs/registry link and runs tested snippets against released artifacts** — new `released-artifacts` job runs `scripts/verify_links.py` (12 URLs from the manifest, README, and docs/*.md verified live; npm package-page URLs probed via the registry API because npmjs.com 403s scripted GETs) and asserts the manifest's `artifact_version` exists in the registry's immutable version list. The consumer smoke runs an import snippet against the installed released artifact. Local runs: both `"status": "passed"`.
4. **Cross-language contract matrix installs Python/npm artifacts in isolated consumer projects** — `scripts/consumer_smoke.py` plans one row per repository across the npm/pypi matrix, installs each `published` artifact in a throwaway consumer project, and asserts installed version == manifest version. Local run: `@bodanglin/verdict-node@0.1.0` installed and imported (`installed: 1, skipped_unreleased: 6`). The pypi executor exists and activates automatically when a Python artifact reaches `published`.
5. **No claim without dated immutable evidence** — every matrix row carries its `evidence_timestamp` and full 40-char `release_train_pin`; publication claims are validated against the registry (criterion 3); maturity/support levels are constrained enums (no "production-ready" claim can pass the checker).
6. **Legacy names explicit and time-bounded** — new required `legacy_aliases` field records `llm-gate-risk` (package), `llm-gate-risk-benchmark` (CLI), and `llm-gate-backtest` (package) with replacements, migration links, and `sunset_date: 2026-12-31`, verified against sibling `pyproject.toml` sources. Checker validates alias shape, kinds, and calendar dates; matrix renders a "Legacy names and migration deadlines" table.
7. **Release-train manifest pins versions with rollback guidance** — retained per-repository `release_train_pin` SHAs plus `docs/COMPATIBILITY_ROLLBACK.md`; rollback link now also surfaced in the generated matrix.
8. **Missing/unreleased components visibly marked** — matrix renders `**not published**` / `**unreleased**` instead of registry links; consumer smoke reports unreleased entries as `skipped` with an explicit reason, never as passing installs.

## Dependencies

verdict-core #10 and verdict-node #9 are both CLOSED — this issue is unblocked. `schema-hashes` and `cross-repository-contract-smoke-tests` remain honestly deferred in the manifest, blocked by verdict-core#220 / verdict-node#31.

## Verification (local, at head SHA)

- `python3 scripts/check_compatibility.py` — passed, 0 warnings
- `python3 scripts/generate_compatibility_matrix.py` — drift check passed
- `python3 scripts/build_evidence.py` — evidence fixtures regenerated and check passed
- `python3 scripts/secret_scan.py .` — passed
- `python3 scripts/verify_links.py` — passed (12 URLs + registry version probe)
- `python3 scripts/consumer_smoke.py` — passed (1 installed, 6 visibly skipped)
- `python3 -m unittest discover -s tests` — 47 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
