### PR TITLE
fix(compatibility): verify exact release train sources

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,30 +12,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: verdict-ecosystem
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-core
           path: verdict-core
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-node
           path: verdict-node
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-risk
           path: verdict-risk
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-strategy
           path: verdict-strategy
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-backtest
           path: verdict-backtest
+          fetch-depth: 0
       - uses: actions/checkout@v4
         with:
           repository: mrnicholasbcarter-code/verdict-cockpit
           path: verdict-cockpit
+          fetch-depth: 0
+      - name: Check out manifest release-train sources
+        working-directory: verdict-ecosystem
+        run: python scripts/checkout_manifest_sources.py
       - name: Validate manifest
         working-directory: verdict-ecosystem
         run: python scripts/check_compatibility.py

--- a/scripts/check_compatibility.py
+++ b/scripts/check_compatibility.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -141,6 +142,17 @@ def validate_manifest(
         rows.append(row)
         if path is not None and not exists:
             errors.append(f"{repo_id}: local repository directory missing: {path}")
+        elif path is not None and path != root:
+            pin_errors, resolved_revision, checked_out_revision = validate_source_pin(
+                repo_id,
+                path,
+                item["release_train_pin"],
+            )
+            errors.extend(pin_errors)
+            row["resolved_release_train_pin"] = resolved_revision
+            row["checked_out_revision"] = checked_out_revision
+        elif path == root:
+            row["source_pin_validation"] = "not-applicable-current-manifest"
 
         validate_repository(item, prefix, repo_id, contract_version, policy_version, root, errors)
         if repo_id == "verdict-strategy" and item["package"] != "verdict-edge":
@@ -153,6 +165,39 @@ def validate_manifest(
     errors.extend(f"missing repository: {repo_id}" for repo_id in sorted(missing_ids))
     errors.extend(f"unexpected repository: {repo_id}" for repo_id in sorted(unexpected_ids))
     return errors, warnings, rows
+
+
+def validate_source_pin(
+    repo_id: str,
+    path: Path,
+    release_train_pin: object,
+) -> tuple[list[str], str | None, str | None]:
+    if not isinstance(release_train_pin, str) or not re.fullmatch(r"[0-9a-f]{40}", release_train_pin):
+        return [], None, None
+
+    def git(*arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(path), *arguments],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    checked_out = git("rev-parse", "HEAD")
+    if checked_out.returncode != 0:
+        return [f"{repo_id}: local repository is not a readable Git checkout"], None, None
+    checked_out_revision = checked_out.stdout.strip()
+
+    resolved = git("rev-parse", "--verify", f"{release_train_pin}^{{commit}}")
+    if resolved.returncode != 0:
+        return [f"{repo_id}: release-train pin is unavailable in local checkout"], None, checked_out_revision
+    resolved_revision = resolved.stdout.strip()
+    if checked_out_revision != resolved_revision:
+        return [
+            f"{repo_id}: checked-out revision differs from release-train pin "
+            f"({checked_out_revision} != {resolved_revision})"
+        ], resolved_revision, checked_out_revision
+    return [], resolved_revision, checked_out_revision
 
 
 def validate_repository(
@@ -293,7 +338,17 @@ def validate_local_path(root: Path, value: object, field: str, errors: list[str]
     if path.is_absolute():
         errors.append(f"{field} must be a relative repository path")
         return None
-    resolved = (root / path).resolve()
+    resolved = root / path
+    normalized_parts: list[str] = []
+    for part in resolved.parts:
+        if part == "..":
+            if normalized_parts and normalized_parts[-1] != "..":
+                normalized_parts.pop()
+            else:
+                normalized_parts.append(part)
+        elif part != ".":
+            normalized_parts.append(part)
+    resolved = Path(*normalized_parts)
     if resolved != root and resolved.parent != root.parent:
         errors.append(f"{field} must resolve to the workspace root or one sibling")
         return None

--- a/scripts/check_compatibility.py
+++ b/scripts/check_compatibility.py
@@ -22,6 +22,7 @@ REQUIRED_IDS = {
     "verdict-cockpit",
     "verdict-ecosystem",
 }
+CANONICAL_PATHS = {repo_id: ("." if repo_id == "verdict-ecosystem" else f"../{repo_id}") for repo_id in REQUIRED_IDS}
 REQUIRED_FIELDS = {
     "id",
     "path",
@@ -128,6 +129,9 @@ def validate_manifest(
         if repo_id in seen:
             errors.append(f"duplicate repository id: {repo_id}")
         seen.add(repo_id)
+
+        if item["path"] != CANONICAL_PATHS.get(repo_id):
+            errors.append(f"{repo_id}: path must use its canonical workspace path {CANONICAL_PATHS.get(repo_id)!r}")
 
         path = validate_local_path(root, item["path"], f"{prefix}.path", errors)
         exists = path.is_dir() if path is not None else False

--- a/scripts/checkout_manifest_sources.py
+++ b/scripts/checkout_manifest_sources.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+CURRENT_REPOSITORY_ID = "verdict-ecosystem"
+
 
 def main(root: Path | None = None) -> int:
     root = root or Path(__file__).resolve().parents[1]
@@ -41,14 +43,22 @@ def main(root: Path | None = None) -> int:
             errors.append(f"{repo_id}: release-train pin must be a full lowercase Git commit SHA")
             continue
 
+        canonical_path = "." if repo_id == CURRENT_REPOSITORY_ID else f"../{repo_id}"
+        if relative_path != canonical_path:
+            errors.append(f"{repo_id}: path must use its canonical workspace path {canonical_path!r}")
+            continue
+
         relative = Path(relative_path)
-        if relative == Path("."):
+        if repo_id == CURRENT_REPOSITORY_ID:
             continue
         if relative.is_absolute() or not relative.parts or relative.parts[0] != ".." or ".." in relative.parts[1:]:
             errors.append(f"{repo_id}: local repository path must name the workspace root or one sibling")
             continue
         path = root.parent / Path(*relative.parts[1:])
-        if path == root:
+        workspace = root.parent.resolve()
+        resolved_path = path.resolve()
+        if path.is_symlink() or resolved_path.parent != workspace or resolved_path != path.absolute():
+            errors.append(f"{repo_id}: local repository path must be a physical workspace sibling")
             continue
         if not path.is_dir():
             errors.append(f"{repo_id}: local repository directory missing: {path}")

--- a/scripts/checkout_manifest_sources.py
+++ b/scripts/checkout_manifest_sources.py
@@ -42,6 +42,8 @@ def main(root: Path | None = None) -> int:
             continue
 
         relative = Path(relative_path)
+        if relative == Path("."):
+            continue
         if relative.is_absolute() or not relative.parts or relative.parts[0] != ".." or ".." in relative.parts[1:]:
             errors.append(f"{repo_id}: local repository path must name the workspace root or one sibling")
             continue

--- a/scripts/checkout_manifest_sources.py
+++ b/scripts/checkout_manifest_sources.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check out external compatibility sources at their manifest pins for CI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main(root: Path | None = None) -> int:
+    root = root or Path(__file__).resolve().parents[1]
+    manifest_path = root / "compatibility-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "error", "errors": [str(exc)]}, indent=2))
+        return 2
+
+    repositories = manifest.get("repositories") if isinstance(manifest, dict) else None
+    if not isinstance(repositories, list):
+        print(json.dumps({"status": "error", "errors": ["manifest.repositories must be an array"]}, indent=2))
+        return 2
+
+    checked_out: list[dict[str, str]] = []
+    errors: list[str] = []
+    for repository in repositories:
+        if not isinstance(repository, dict):
+            errors.append("manifest repository entry must be an object")
+            continue
+
+        repo_id = repository.get("id")
+        relative_path = repository.get("path")
+        release_train_pin = repository.get("release_train_pin")
+        if not isinstance(repo_id, str) or not isinstance(relative_path, str):
+            errors.append("manifest repository id and path must be text")
+            continue
+        if not isinstance(release_train_pin, str) or not re.fullmatch(r"[0-9a-f]{40}", release_train_pin):
+            errors.append(f"{repo_id}: release-train pin must be a full lowercase Git commit SHA")
+            continue
+
+        relative = Path(relative_path)
+        if relative.is_absolute() or not relative.parts or relative.parts[0] != ".." or ".." in relative.parts[1:]:
+            errors.append(f"{repo_id}: local repository path must name the workspace root or one sibling")
+            continue
+        path = root.parent / Path(*relative.parts[1:])
+        if path == root:
+            continue
+        if not path.is_dir():
+            errors.append(f"{repo_id}: local repository directory missing: {path}")
+            continue
+
+        try:
+            run_git(path, "fetch", "--depth=1", "origin", release_train_pin)
+            run_git(path, "checkout", "--detach", "--quiet", release_train_pin)
+        except subprocess.CalledProcessError as exc:
+            detail = exc.stderr.strip() or exc.stdout.strip() or "git command failed"
+            errors.append(f"{repo_id}: could not check out release-train pin: {detail}")
+            continue
+
+        checked_out.append({"id": repo_id, "release_train_pin": release_train_pin})
+
+    report = {
+        "status": "failed" if errors else "passed",
+        "checked_out": checked_out,
+        "errors": errors,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if errors else 0
+
+
+def run_git(path: Path, *arguments: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(path), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_compatibility.py
+++ b/tests/test_check_compatibility.py
@@ -286,6 +286,26 @@ class CheckoutManifestSourcesTests(unittest.TestCase):
             ],
         )
 
+    def test_current_manifest_repository_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "verdict-ecosystem"
+            root.mkdir()
+            manifest = {
+                "repositories": [
+                    {
+                        "id": "verdict-ecosystem",
+                        "path": ".",
+                        "release_train_pin": "a" * 40,
+                    }
+                ]
+            }
+            (root / "compatibility-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with patch.object(self.checkout, "run_git") as run_git:
+                exit_code = self.checkout.main(root)
+
+        self.assertEqual(exit_code, 0)
+        run_git.assert_not_called()
+
     def test_manifest_path_cannot_escape_the_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             workspace = Path(temporary_directory) / "workspace"

--- a/tests/test_check_compatibility.py
+++ b/tests/test_check_compatibility.py
@@ -34,15 +34,21 @@ class CompatibilityManifestTests(unittest.TestCase):
         mutate(manifest)
         if not use_local_paths:
             for repository in manifest["repositories"]:
-                repository["path"] = "."
-        errors, _, _ = CHECKER.validate_manifest(self.validation_root, manifest)
+                repository["path"] = CHECKER.CANONICAL_PATHS[repository["id"]]
+        with patch.object(Path, "is_dir", return_value=True), patch.object(
+            CHECKER, "validate_source_pin", return_value=([], "a" * 40, "a" * 40)
+        ):
+            errors, _, _ = CHECKER.validate_manifest(self.validation_root, manifest)
         return errors
 
     def test_current_manifest_passes(self) -> None:
         manifest = copy.deepcopy(self.manifest)
         for repository in manifest["repositories"]:
-            repository["path"] = "."
-        errors, _, rows = CHECKER.validate_manifest(self.validation_root, manifest)
+            repository["path"] = CHECKER.CANONICAL_PATHS[repository["id"]]
+        with patch.object(Path, "is_dir", return_value=True), patch.object(
+            CHECKER, "validate_source_pin", return_value=([], "a" * 40, "a" * 40)
+        ):
+            errors, _, rows = CHECKER.validate_manifest(self.validation_root, manifest)
         self.assertEqual(errors, [])
         self.assertEqual(len(rows), 7)
 
@@ -64,6 +70,13 @@ class CompatibilityManifestTests(unittest.TestCase):
             use_local_paths=True,
         )
         self.assertTrue(any("workspace root or one sibling" in error for error in errors))
+
+    def test_external_repository_cannot_claim_current_manifest_path(self) -> None:
+        errors = self.validate(
+            lambda value: value["repositories"][0].update(path="."),
+            use_local_paths=True,
+        )
+        self.assertTrue(any("must use its canonical workspace path" in error for error in errors))
 
     def test_secret_bearing_url_metadata_fails(self) -> None:
         errors = self.validate(
@@ -306,6 +319,26 @@ class CheckoutManifestSourcesTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         run_git.assert_not_called()
 
+    def test_external_repository_cannot_claim_current_manifest_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory) / "verdict-ecosystem"
+            root.mkdir()
+            manifest = {
+                "repositories": [
+                    {
+                        "id": "verdict-core",
+                        "path": ".",
+                        "release_train_pin": "a" * 40,
+                    }
+                ]
+            }
+            (root / "compatibility-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with patch.object(self.checkout, "run_git") as run_git:
+                exit_code = self.checkout.main(root)
+
+        self.assertEqual(exit_code, 1)
+        run_git.assert_not_called()
+
     def test_manifest_path_cannot_escape_the_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             workspace = Path(temporary_directory) / "workspace"
@@ -318,6 +351,30 @@ class CheckoutManifestSourcesTests(unittest.TestCase):
                     {
                         "id": "verdict-core",
                         "path": "../../outside",
+                        "release_train_pin": "a" * 40,
+                    }
+                ]
+            }
+            (root / "compatibility-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with patch.object(self.checkout, "run_git") as run_git:
+                exit_code = self.checkout.main(root)
+
+        self.assertEqual(exit_code, 1)
+        run_git.assert_not_called()
+
+    def test_symlinked_sibling_cannot_escape_the_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            workspace = Path(temporary_directory) / "workspace"
+            root = workspace / "verdict-ecosystem"
+            root.mkdir(parents=True)
+            outside = Path(temporary_directory) / "outside"
+            outside.mkdir()
+            (workspace / "verdict-core").symlink_to(outside, target_is_directory=True)
+            manifest = {
+                "repositories": [
+                    {
+                        "id": "verdict-core",
+                        "path": "../verdict-core",
                         "release_train_pin": "a" * 40,
                     }
                 ]

--- a/tests/test_check_compatibility.py
+++ b/tests/test_check_compatibility.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location(
@@ -24,15 +27,22 @@ class CompatibilityManifestTests(unittest.TestCase):
         cls.manifest = json.loads(
             (ROOT / "compatibility-manifest.json").read_text(encoding="utf-8")
         )
+        cls.validation_root = ROOT
 
-    def validate(self, mutate) -> list[str]:
+    def validate(self, mutate, *, use_local_paths: bool = False) -> list[str]:
         manifest = copy.deepcopy(self.manifest)
         mutate(manifest)
-        errors, _, _ = CHECKER.validate_manifest(ROOT, manifest)
+        if not use_local_paths:
+            for repository in manifest["repositories"]:
+                repository["path"] = "."
+        errors, _, _ = CHECKER.validate_manifest(self.validation_root, manifest)
         return errors
 
     def test_current_manifest_passes(self) -> None:
-        errors, _, rows = CHECKER.validate_manifest(ROOT, self.manifest)
+        manifest = copy.deepcopy(self.manifest)
+        for repository in manifest["repositories"]:
+            repository["path"] = "."
+        errors, _, rows = CHECKER.validate_manifest(self.validation_root, manifest)
         self.assertEqual(errors, [])
         self.assertEqual(len(rows), 7)
 
@@ -50,7 +60,8 @@ class CompatibilityManifestTests(unittest.TestCase):
 
     def test_parent_escape_path_fails(self) -> None:
         errors = self.validate(
-            lambda value: value["repositories"][0].update(path="../../outside")
+            lambda value: value["repositories"][0].update(path="../../outside"),
+            use_local_paths=True,
         )
         self.assertTrue(any("workspace root or one sibling" in error for error in errors))
 
@@ -153,6 +164,150 @@ class CompatibilityManifestTests(unittest.TestCase):
             lambda value: value["release_train"]["deferred_checks"].clear()
         )
         self.assertTrue(any("ratified REL-001 blockers" in error for error in errors))
+
+
+class SourcePinResolutionTests(unittest.TestCase):
+    def create_repository(self, directory: Path) -> tuple[str, str]:
+        directory.mkdir()
+        self.run_git(directory, "init", "--quiet")
+        self.run_git(directory, "config", "user.email", "compatibility@example.test")
+        self.run_git(directory, "config", "user.name", "Compatibility Test")
+        (directory / "state.txt").write_text("pinned\n", encoding="utf-8")
+        self.run_git(directory, "add", "state.txt")
+        self.run_git(directory, "commit", "--quiet", "-m", "pinned state")
+        pinned_revision = self.run_git(directory, "rev-parse", "HEAD")
+        (directory / "state.txt").write_text("different\n", encoding="utf-8")
+        self.run_git(directory, "commit", "--quiet", "-am", "different state")
+        current_revision = self.run_git(directory, "rev-parse", "HEAD")
+        return pinned_revision, current_revision
+
+    def run_git(self, directory: Path, *arguments: str) -> str:
+        completed = subprocess.run(
+            ["git", "-C", str(directory), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    def test_exact_source_pin_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory) / "repository"
+            pinned_revision, _ = self.create_repository(repository)
+            self.run_git(repository, "checkout", "--quiet", "--detach", pinned_revision)
+
+            errors, resolved_revision, checked_out_revision = CHECKER.validate_source_pin(
+                "verdict-core", repository, pinned_revision
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(resolved_revision, pinned_revision)
+        self.assertEqual(checked_out_revision, pinned_revision)
+
+    def test_incompatible_checked_out_revision_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory) / "repository"
+            pinned_revision, current_revision = self.create_repository(repository)
+
+            errors, resolved_revision, checked_out_revision = CHECKER.validate_source_pin(
+                "verdict-core", repository, pinned_revision
+            )
+
+        self.assertTrue(any("checked-out revision differs" in error for error in errors))
+        self.assertEqual(resolved_revision, pinned_revision)
+        self.assertEqual(checked_out_revision, current_revision)
+
+    def test_missing_source_pin_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory) / "repository"
+            self.create_repository(repository)
+
+            errors, resolved_revision, checked_out_revision = CHECKER.validate_source_pin(
+                "verdict-core", repository, "a" * 40
+            )
+
+        self.assertTrue(any("release-train pin is unavailable" in error for error in errors))
+        self.assertIsNone(resolved_revision)
+        self.assertIsNotNone(checked_out_revision)
+
+    def test_non_git_directory_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory) / "not-a-repository"
+            directory.mkdir()
+
+            errors, resolved_revision, checked_out_revision = CHECKER.validate_source_pin(
+                "verdict-core", directory, "a" * 40
+            )
+
+        self.assertTrue(any("not a readable Git checkout" in error for error in errors))
+        self.assertIsNone(resolved_revision)
+        self.assertIsNone(checked_out_revision)
+
+
+class CheckoutManifestSourcesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "checkout_manifest_sources",
+            ROOT / "scripts" / "checkout_manifest_sources.py",
+        )
+        assert spec and spec.loader
+        cls.checkout = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cls.checkout
+        spec.loader.exec_module(cls.checkout)
+
+    def test_pin_checkout_fetches_exact_revision_then_detaches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            manifest = {
+                "repositories": [
+                    {
+                        "id": "verdict-core",
+                        "path": "../verdict-core",
+                        "release_train_pin": "a" * 40,
+                    }
+                ]
+            }
+            (directory / "compatibility-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            (directory.parent / "verdict-core").mkdir(exist_ok=True)
+
+            calls: list[tuple[Path, tuple[str, ...]]] = []
+            with patch.object(
+                self.checkout, "run_git", side_effect=lambda path, *arguments: calls.append((path, arguments))
+            ):
+                exit_code = self.checkout.main(directory)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            calls,
+            [
+                (directory.parent / "verdict-core", ("fetch", "--depth=1", "origin", "a" * 40)),
+                (directory.parent / "verdict-core", ("checkout", "--detach", "--quiet", "a" * 40)),
+            ],
+        )
+
+    def test_manifest_path_cannot_escape_the_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            workspace = Path(temporary_directory) / "workspace"
+            root = workspace / "verdict-ecosystem"
+            root.mkdir(parents=True)
+            outside = Path(temporary_directory) / "outside"
+            outside.mkdir()
+            manifest = {
+                "repositories": [
+                    {
+                        "id": "verdict-core",
+                        "path": "../../outside",
+                        "release_train_pin": "a" * 40,
+                    }
+                ]
+            }
+            (root / "compatibility-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with patch.object(self.checkout, "run_git") as run_git:
+                exit_code = self.checkout.main(root)
+
+        self.assertEqual(exit_code, 1)
+        run_git.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- check out every external repository at its manifest-pinned commit before compatibility validation
- fail closed when a checked-out source does not match its release-train pin
- cover exact, mismatched, missing, non-Git, and traversal failure paths

## Verification

- `python3 -m unittest discover -s tests -v` (53 passed)
- `python3 scripts/build_evidence.py`
- `python3 scripts/inventory_check.py .`
- `python3 scripts/secret_scan.py .`
- `python3 scripts/generate_compatibility_matrix.py`
- `git diff --check`
- generated evidence/matrix remained unchanged

## Scope

This is the scoped Ecosystem compatibility WorkUnit for portfolio MVP tasks T011-T013. It does not publish artifacts or mutate account/routing state.